### PR TITLE
Add --apply flag to run kubectl apply

### DIFF
--- a/cmd/kritis/kubectl/plugins/resolve/README.md
+++ b/cmd/kritis/kubectl/plugins/resolve/README.md
@@ -19,6 +19,11 @@ You can then run the plugin:
 kubectl plugin resolve-tags -f <path to file>
 ```
 
+To apply subsitutions using `kubectl apply -f`, you can run:
+```
+kubectl plugin resolve-tags -f <path to file> -a true
+```
+
 ## resolve-tags binary
 
 resolve-tags can also be run as a binary. 
@@ -35,4 +40,8 @@ You can then run the binary:
 
 ```
 ./out/resolve-tags -f <path to file> -f <path to another file>
+```
+To apply subsitutions using `kubectl apply -f`, you can run:
+```
+kubectl plugin resolve-tags -f <path to file> -a
 ```

--- a/cmd/kritis/kubectl/plugins/resolve/cmd/root_test.go
+++ b/cmd/kritis/kubectl/plugins/resolve/cmd/root_test.go
@@ -38,11 +38,11 @@ spec:
 
 func Test_RootCmd(t *testing.T) {
 	initial := fmt.Sprintf(testYaml, "gcr.io/kritis-int-test/resolve-tags-test-image")
-	expected := fmt.Sprintf(testYaml+"\n", "gcr.io/kritis-int-test/resolve-tags-test-image@sha256:3e2e946cb834c4538b789312d566eb16f4a27734fc6b140a3b3f85baafce965f")
 	file, err := ioutil.TempFile("", "")
 	if err != nil {
 		t.Error(err)
 	}
+	expected := fmt.Sprintf("---%s---"+"\n"+testYaml+"\n", file.Name(), "gcr.io/kritis-int-test/resolve-tags-test-image@sha256:3e2e946cb834c4538b789312d566eb16f4a27734fc6b140a3b3f85baafce965f")
 	if _, err := io.Copy(file, bytes.NewReader([]byte(initial))); err != nil {
 		t.Error(err)
 	}

--- a/cmd/kritis/kubectl/plugins/resolve/plugin.yaml
+++ b/cmd/kritis/kubectl/plugins/resolve/plugin.yaml
@@ -5,4 +5,6 @@ flags:
   - name: "filename"
     shorthand: "f"
     desc: "files to be resolved"
-
+  - name: "apply"
+    shorthand: "a"
+    desc: "run `kubectl apply -f` after substitution"

--- a/pkg/kritis/kubectl/plugins/resolve/resolve.go
+++ b/pkg/kritis/kubectl/plugins/resolve/resolve.go
@@ -22,34 +22,35 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"gopkg.in/yaml.v2"
-	"io"
 	"io/ioutil"
 )
 
-// Execute replaces image:tag with image:digest in each file and prints to the writer
-func Execute(files []string, writer io.Writer) error {
+// Execute replaces image:tag with image:digest in each file
+// It returns a map of [file name]:[new contents]
+func Execute(files []string) (map[string]string, error) {
+	substitutes := map[string]string{}
 	for _, file := range files {
 		contents, err := ioutil.ReadFile(file)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		m := yaml.MapSlice{}
 		if err := yaml.Unmarshal(contents, &m); err != nil {
-			return err
+			return nil, err
 		}
 		taggedImages := recursiveGetTaggedImages(m)
 		resolvedImages, err := resolveTagsToDigests(taggedImages)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		replacedYaml := recursiveReplaceImage(m, resolvedImages)
 		updatedManifest, err := yaml.Marshal(replacedYaml)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		print(updatedManifest, writer)
+		substitutes[file] = string(updatedManifest)
 	}
-	return nil
+	return substitutes, nil
 }
 
 // For testing
@@ -143,10 +144,4 @@ func recursiveReplaceImage(i interface{}, replacements map[string]string) interf
 		return t
 	}
 	return nil
-}
-
-// prints the final replaced kubernetes manifest to given writer
-func print(mfst []byte, writer io.Writer) {
-	fmt.Fprintf(writer, string(mfst))
-	fmt.Fprintln(writer)
 }


### PR DESCRIPTION
I changed `Execute()` in the `resolve` package to return a map of [file name]:[new contents]. If the --apply flag is set, the plugin will save the new contents to a commands stdin and then execute the `kubectl apply -f` command.

Should finish #2 