### PR TITLE
Return interface as default when replacing tags and unit test

### DIFF
--- a/pkg/kritis/kubectl/plugins/resolve/resolve.go
+++ b/pkg/kritis/kubectl/plugins/resolve/resolve.go
@@ -141,8 +141,9 @@ func recursiveReplaceImage(i interface{}, replacements map[string]string) interf
 			t[index] = replacedMapSlice
 		}
 		return t
+	default:
+		return t
 	}
-	return nil
 }
 
 // prints the final replaced kubernetes manifest to given writer

--- a/pkg/kritis/kubectl/plugins/resolve/resolve_test.go
+++ b/pkg/kritis/kubectl/plugins/resolve/resolve_test.go
@@ -31,6 +31,9 @@ spec:
   containers:
   - name: docker
     image: golang:1.10
+    args: ["--arg1=<first>",
+	       "--arg2=<second>",
+	       "--arg3=<third>"]
 `
 
 var testYaml2 = `apiVersion: v1


### PR DESCRIPTION
Fixes #40 

Arrays of strings, like in the kaniko example, were being typed as an interface{}, so the default nil was being returned. Instead, I changed the default to return the interface (which should always be a string)