### PR TITLE
Added validation check to admission webhook and unit tests

### DIFF
--- a/pkg/kritis/admission/admission.go
+++ b/pkg/kritis/admission/admission.go
@@ -18,45 +18,147 @@ package admission
 
 import (
 	"encoding/json"
+	"fmt"
+	"github.com/grafeas/kritis/pkg/kritis/admission/constants"
+	kritisv1beta1 "github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
+	"github.com/grafeas/kritis/pkg/kritis/crd/securitypolicy"
+	"github.com/grafeas/kritis/pkg/kritis/kubectl/plugins/resolve"
+	"github.com/grafeas/kritis/pkg/kritis/metadata"
+	"github.com/grafeas/kritis/pkg/kritis/metadata/containeranalysis"
+	"github.com/grafeas/kritis/pkg/kritis/pods"
+	"io/ioutil"
+	"k8s.io/api/admission/v1beta1"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"log"
 	"net/http"
-
-	"github.com/grafeas/kritis/pkg/kritis/admission/constants"
-	"k8s.io/api/admission/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// This is very basic admission controller which allows all pods.
+type config struct {
+	retrievePod           func(r *http.Request) (*v1.Pod, error)
+	imagesecuritypolicies func(namespace string) ([]kritisv1beta1.ImageSecurityPolicy, error)
+	validate              func(isp kritisv1beta1.ImageSecurityPolicy, project, image string, client metadata.MetadataFetcher) ([]metadata.Vulnerability, error)
+}
+
+var (
+	// For testing
+	admissionConfig = config{
+		retrievePod:           pod,
+		imagesecuritypolicies: securitypolicy.ImageSecurityPolicies,
+		validate:              securitypolicy.ValidateImageSecurityPolicy,
+	}
+)
+
+// This admission controller looks for the breakglass annotation
+// If one is not found, it validates against image security policies
+// TODO: Check for attestations
 func AdmissionReviewHandler(w http.ResponseWriter, r *http.Request) {
-	// TODO: Add image security policy check
-	// 1. Get all Image security Polices
-	// 2. Get all pod specs
-	// 3. For all pods Get Vulnerabilities for images
-	// 4. Validate policy
-	// 5. Attest.
-	status := &v1beta1.AdmissionResponse{
-		Allowed: true,
+	pod, err := admissionConfig.retrievePod(r)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	// First, check for a breakglass annotation on the pod
+	if breakglass(pod) {
+		returnStatus(constants.SuccessStatus, constants.SuccessMessage, w)
+		return
+	}
+	// Second, get all images in the pod and make sure they are fully qualified
+	images := pods.Images(*pod)
+	for _, image := range images {
+		if !resolve.FullyQualifiedImage(image) {
+			returnStatus(constants.FailureStatus, fmt.Sprintf("%s is not a fully qualified image", image), w)
+			return
+		}
+	}
+	// Third, validate images in the pod against ImageSecurityPolicies in the same namespace
+	isps, err := admissionConfig.imagesecuritypolicies(pod.Namespace)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	// get the client we will get vulnz from
+	metadataClient, err := metadataClient()
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	for _, isp := range isps {
+		for _, image := range images {
+			violations, err := admissionConfig.validate(isp, "", image, metadataClient)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			if len(violations) != 0 {
+				//  TODO: Check AttestationAuthorities to see if the image is verified
+				log.Printf("found violations in %s: %v\n", image, violations)
+				returnStatus(constants.FailureStatus, fmt.Sprintf("found violations in %s", image), w)
+				return
+			}
+		}
+	}
+	// At this point, we can return a success status
+	returnStatus(constants.SuccessStatus, constants.SuccessMessage, w)
+}
+
+func pod(r *http.Request) (*v1.Pod, error) {
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	ar := v1beta1.AdmissionReview{}
+	if err := json.Unmarshal(data, &ar); err != nil {
+		return nil, err
+	}
+	pod := v1.Pod{}
+	if err := json.Unmarshal(ar.Request.Object.Raw, &pod); err != nil {
+		return nil, err
+	}
+	return &pod, nil
+}
+
+func breakglass(pod *v1.Pod) bool {
+	annotations := pod.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	_, ok := annotations[constants.BREAKGLASS]
+	return ok
+}
+
+// TODO: update this once we have more metadata clients
+func metadataClient() (metadata.MetadataFetcher, error) {
+	return containeranalysis.NewContainerAnalysisClient()
+}
+
+func returnStatus(status constants.Status, message string, w http.ResponseWriter) {
+	response := &v1beta1.AdmissionResponse{
+		Allowed: (status == constants.SuccessStatus),
 		Result: &metav1.Status{
-			Status:  string(constants.SuccessStatus),
-			Message: constants.SuccessMessage,
+			Status:  string(status),
+			Message: message,
 		},
 	}
-	error := WriteHttpResponse(status, w)
-	if error != nil {
-		log.Printf("\nError writing response %s", error)
+	if err := writeHttpResponse(response, w); err != nil {
+		log.Println("error writing response:", err)
 	}
 }
 
-func WriteHttpResponse(status *v1beta1.AdmissionResponse, w http.ResponseWriter) error {
+func writeHttpResponse(response *v1beta1.AdmissionResponse, w http.ResponseWriter) error {
 	ar := v1beta1.AdmissionReview{
-		Response: status,
+		Response: response,
 	}
 	data, err := json.Marshal(ar)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return nil
 	}
-	w.WriteHeader(http.StatusOK)
-	_, error := w.Write(data)
-	return error
+	if response.Allowed {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusBadRequest)
+	}
+	_, err = w.Write(data)
+	return err
 }

--- a/pkg/kritis/admission/admission_test.go
+++ b/pkg/kritis/admission/admission_test.go
@@ -17,32 +17,159 @@ limitations under the License.
 package admission
 
 import (
+	"fmt"
+	"github.com/grafeas/kritis/pkg/kritis/admission/constants"
+	kritisv1beta1 "github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
+	"github.com/grafeas/kritis/pkg/kritis/crd/securitypolicy"
+	"github.com/grafeas/kritis/pkg/kritis/metadata"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 )
 
-func TestAdmissionReviewHandler(t *testing.T) {
+const (
+	validImage = "gcr.io/image/digest@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+)
+
+type testConfig struct {
+	mockConfig config
+	httpStatus int
+	allowed    bool
+	status     constants.Status
+	message    string
+}
+
+func Test_BreakglassAnnotation(t *testing.T) {
+	mockPod := func(r *http.Request) (*v1.Pod, error) {
+		return &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"breakglass": "true"},
+			},
+		}, nil
+	}
+	mockConfig := config{
+		retrievePod: mockPod,
+	}
+	RunTest(t, testConfig{
+		mockConfig: mockConfig,
+		httpStatus: http.StatusOK,
+		allowed:    true,
+		status:     constants.SuccessStatus,
+		message:    constants.SuccessMessage,
+	})
+}
+
+func Test_UnqualifiedImage(t *testing.T) {
+	mockPod := func(r *http.Request) (*v1.Pod, error) {
+		return &v1.Pod{
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Image: "image:tag",
+					},
+				},
+			},
+		}, nil
+	}
+	mockConfig := config{
+		retrievePod: mockPod,
+	}
+	RunTest(t, testConfig{
+		mockConfig: mockConfig,
+		httpStatus: http.StatusBadRequest,
+		allowed:    false,
+		status:     constants.FailureStatus,
+		message:    "image:tag is not a fully qualified image",
+	})
+}
+
+func Test_ValidISP(t *testing.T) {
+	mockISP := func(namespace string) ([]kritisv1beta1.ImageSecurityPolicy, error) {
+		return []kritisv1beta1.ImageSecurityPolicy{
+			{
+				ImageWhitelist: []string{validImage},
+			},
+		}, nil
+	}
+	mockConfig := config{
+		retrievePod:           mockValidPod(),
+		imagesecuritypolicies: mockISP,
+		validate:              securitypolicy.ValidateImageSecurityPolicy,
+	}
+	RunTest(t, testConfig{
+		mockConfig: mockConfig,
+		httpStatus: http.StatusOK,
+		allowed:    true,
+		status:     constants.SuccessStatus,
+		message:    constants.SuccessMessage,
+	})
+}
+
+func Test_InvalidISP(t *testing.T) {
+	mockISP := func(namespace string) ([]kritisv1beta1.ImageSecurityPolicy, error) {
+		return []kritisv1beta1.ImageSecurityPolicy{{}}, nil
+	}
+	mockValidate := func(isp kritisv1beta1.ImageSecurityPolicy, project, image string, client metadata.MetadataFetcher) ([]metadata.Vulnerability, error) {
+		return []metadata.Vulnerability{
+			{
+				Severity: "foo",
+			},
+		}, nil
+	}
+	mockConfig := config{
+		retrievePod:           mockValidPod(),
+		imagesecuritypolicies: mockISP,
+		validate:              mockValidate,
+	}
+	RunTest(t, testConfig{
+		mockConfig: mockConfig,
+		httpStatus: http.StatusBadRequest,
+		allowed:    false,
+		status:     constants.FailureStatus,
+		message:    fmt.Sprintf("found violations in %s", validImage),
+	})
+}
+
+func mockValidPod() func(r *http.Request) (*v1.Pod, error) {
+	return func(r *http.Request) (*v1.Pod, error) {
+		return &v1.Pod{
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Image: validImage,
+					},
+				},
+			},
+		}, nil
+	}
+}
+
+func RunTest(t *testing.T, tc testConfig) {
 	// Create a request to pass to our handler.
 	req, err := http.NewRequest("GET", "/", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	// Create mocks
+	original := admissionConfig
+	defer func() {
+		admissionConfig = original
+	}()
+	admissionConfig = tc.mockConfig
 	// Create a ResponseRecorder to record the response.
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(AdmissionReviewHandler)
-
 	handler.ServeHTTP(rr, req)
-
 	// Check the status code is what we expect.
-	if status := rr.Code; status != http.StatusOK {
+	if status := rr.Code; status != tc.httpStatus {
 		t.Errorf("handler returned wrong status code: got %v want %v",
-			status, http.StatusOK)
+			status, tc.httpStatus)
 	}
-
 	// Check the response body is what we expect.
-	expected := `{"response":{"uid":"","allowed":true,"status":{"metadata":{},"status":"Success","message":"Successfully admitted."}}}`
+	expected := `{"response":{"uid":"","allowed":%t,"status":{"metadata":{},"status":"%s","message":"%s"}}}`
+	expected = fmt.Sprintf(expected, tc.allowed, tc.status, tc.message)
 	if rr.Body.String() != expected {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), expected)

--- a/pkg/kritis/admission/constants/constants.go
+++ b/pkg/kritis/admission/constants/constants.go
@@ -28,4 +28,6 @@ const (
 
 const (
 	SuccessMessage = "Successfully admitted."
+	// BREAKGLASS is the annotation used to allow any pod past the webhook
+	BREAKGLASS = "breakglass"
 )

--- a/pkg/kritis/crd/securitypolicy/securitypolicy.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy.go
@@ -27,8 +27,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// ImageSecurityPolicies returns all ISP's in all namespaces
-func ImageSecurityPolicies() ([]v1beta1.ImageSecurityPolicy, error) {
+// ImageSecurityPolicies returns all ISP's in the specified namespaces
+// Pass in an empty string to get all ISPs in all namespaces
+func ImageSecurityPolicies(namespace string) ([]v1beta1.ImageSecurityPolicy, error) {
 	cfg, err := clientcmd.BuildConfigFromFlags("", "")
 	if err != nil {
 		return nil, fmt.Errorf("error building config: %v", err)
@@ -38,7 +39,7 @@ func ImageSecurityPolicies() ([]v1beta1.ImageSecurityPolicy, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error building clientset: %v", err)
 	}
-	list, err := client.KritisV1beta1().ImageSecurityPolicies("").List(metav1.ListOptions{})
+	list, err := client.KritisV1beta1().ImageSecurityPolicies(namespace).List(metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error listing all image policy requirements: %v", err)
 	}
@@ -53,7 +54,10 @@ func ValidateImageSecurityPolicy(isp v1beta1.ImageSecurityPolicy, project, image
 		return nil, nil
 	}
 	// Now, check vulnz in the image
-	vulnz := client.GetVulnerabilities(project, image)
+	vulnz, err := client.GetVulnerabilities(project, image)
+	if err != nil {
+		return nil, err
+	}
 	var violations []metadata.Vulnerability
 
 	for _, v := range vulnz {

--- a/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
@@ -40,11 +40,11 @@ var (
 type mockMetadataClient struct {
 }
 
-func (m mockMetadataClient) GetVulnerabilities(project string, containerImage string) []metadata.Vulnerability {
+func (m mockMetadataClient) GetVulnerabilities(project string, containerImage string) ([]metadata.Vulnerability, error) {
 	return []metadata.Vulnerability{
 		vulnz1,
 		vulnz2,
-	}
+	}, nil
 }
 
 func Test_ValidISP(t *testing.T) {

--- a/pkg/kritis/kubectl/plugins/resolve/resolve.go
+++ b/pkg/kritis/kubectl/plugins/resolve/resolve.go
@@ -83,8 +83,7 @@ func recursiveGetTaggedImages(m interface{}) []string {
 	case yaml.MapItem:
 		if t.Key.(string) == "image" {
 			image := t.Value.(string)
-			_, err := name.NewDigest(image, name.WeakValidation)
-			if err != nil {
+			if !FullyQualifiedImage(image) {
 				images = append(images, image)
 			}
 		} else {
@@ -96,6 +95,12 @@ func recursiveGetTaggedImages(m interface{}) []string {
 		}
 	}
 	return images
+}
+
+// FullyQualifiedImage returns true if the image is fully qualified
+func FullyQualifiedImage(image string) bool {
+	_, err := name.NewDigest(image, name.WeakValidation)
+	return err == nil
 }
 
 // resolveTagsToDigests resolves all images specified by tag to digest

--- a/pkg/kritis/metadata/metadata.go
+++ b/pkg/kritis/metadata/metadata.go
@@ -18,7 +18,7 @@ package metadata
 
 type MetadataFetcher interface {
 	// Get Package Vulnerabilites
-	GetVulnerabilities(project string, containerImage string) []Vulnerability
+	GetVulnerabilities(project string, containerImage string) ([]Vulnerability, error)
 }
 
 type Vulnerability struct {


### PR DESCRIPTION
Currently the admission webhook accepts everything, so I added a check for the "breakglass" annotation and validation against ImageSecurityPolicies.

Partially fixes #8, although we still need to add all the AttestationAuthority stuff