### PR TITLE
Return violations if image is unqualified

### DIFF
--- a/pkg/kritis/crd/securitypolicy/securitypolicy.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy.go
@@ -61,6 +61,7 @@ func ValidateImageSecurityPolicy(isp v1beta1.ImageSecurityPolicy, image string, 
 			Violation: UnqualifiedImageViolation,
 			Reason:    UnqualifiedImageViolationReason(image),
 		})
+		return violations, nil
 	}
 	// Now, check vulnz in the image
 	vulnz, err := client.GetVulnerabilities(image)


### PR DESCRIPTION
If an image is unqualified, return violations instead of trying to get vulnz (which we can't get since the image is unqualified)

I was getting a generic error message instead of "image is unqualified" since kritis was unable to get the vulnz 