### PR TITLE
Add attestation logic PR 3 of 4

### DIFF
--- a/pkg/kritis/constants/constants.go
+++ b/pkg/kritis/constants/constants.go
@@ -37,6 +37,10 @@ const (
 	// Public Key Private Key constants for Attestation Secrets.
 	PrivateKey = "private"
 	PublicKey  = "public"
+
+	// Constants for Metadata Library
+	PageSize          = int32(100)
+	ResourceUrlPrefix = "https://"
 )
 
 var (

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
@@ -80,10 +80,12 @@ func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
 		PublicKey:  pub,
 		SecretName: "test",
 	}
-	err = d.CreateAttestationOccurence(note, testutil.IntTestImage, secret)
+
+	occ, err := d.CreateAttestationOccurence(note, testutil.IntTestImage, secret)
 	if err != nil {
 		t.Fatalf("Unexpected error while creating Occurence %v", err)
 	}
+	defer d.DeleteOccurrence(occ.GetName())
 	occurrences, err := d.GetAttestations(testutil.IntTestImage)
 	if err != nil {
 		t.Fatalf("Unexpected error while listing Occ %v", err)
@@ -91,5 +93,5 @@ func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
 	if occurrences == nil {
 		t.Fatal("Shd have created atleast 1 occurrence")
 	}
-	defer d.DeleteOccurrences(occurrences)
+
 }

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 
 	kritisv1beta1 "github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
+	"github.com/grafeas/kritis/pkg/kritis/secrets"
+	"github.com/grafeas/kritis/pkg/kritis/testutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -46,7 +48,7 @@ func TestGetVulnerabilities(t *testing.T) {
 	}
 }
 
-func TestCreateAttestationNote(t *testing.T) {
+func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
 	d, err := NewContainerAnalysisClient()
 	aa := kritisv1beta1.AttestationAuthority{
 		NoteReference: fmt.Sprintf("%s/projects/%s", IntAPI, IntProject),
@@ -71,4 +73,23 @@ func TestCreateAttestationNote(t *testing.T) {
 	if actualHint != IntTestNoteName {
 		t.Fatalf("Expected %s.\n Got %s", expectedNoteName, actualHint)
 	}
+	// Test Create Attestation Occurence
+	pub, priv := testutil.CreateBase64KeyPair(t)
+	secret := &secrets.PgpSigningSecret{
+		PrivateKey: priv,
+		PublicKey:  pub,
+		SecretName: "test",
+	}
+	err = d.CreateAttestationOccurence(note, testutil.IntTestImage, secret)
+	if err != nil {
+		t.Fatalf("Unexpected error while creating Occurence %v", err)
+	}
+	occurrences, err := d.GetAttestations(testutil.IntTestImage)
+	if err != nil {
+		t.Fatalf("Unexpected error while listing Occ %v", err)
+	}
+	if occurrences == nil {
+		t.Fatal("Shd have created atleast 1 occurrence")
+	}
+	defer d.DeleteOccurrences(occurrences)
 }

--- a/pkg/kritis/testutil/constants.go
+++ b/pkg/kritis/testutil/constants.go
@@ -18,4 +18,5 @@ package testutil
 
 const (
 	QualifiedImage = "gcr.io/image/digest@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	IntTestImage   = "gcr.io/kritis-int-test/test-image@sha256:3e2e946cb834c4538b789312d566eb16f4a27734fc6b140a3b3f85baafce965f"
 )

--- a/pkg/kritis/util/util.go
+++ b/pkg/kritis/util/util.go
@@ -17,8 +17,11 @@ limitations under the License.
 package util
 
 import (
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/grafeas/kritis/pkg/kritis/attestation"
+	"github.com/grafeas/kritis/pkg/kritis/secrets"
+	"github.com/spf13/cobra"
 )
 
 func ExitIfErr(cmd *cobra.Command, err error) {
@@ -26,4 +29,16 @@ func ExitIfErr(cmd *cobra.Command, err error) {
 		cmd.Println(err)
 		os.Exit(1)
 	}
+}
+
+func CreateAttestationSignature(image string, pgpSigningKey *secrets.PgpSigningSecret) (string, error) {
+	hostSig, err := NewAtomicContainerSig(image, map[string]string{})
+	if err != nil {
+		return "", err
+	}
+	hostStr, err := hostSig.Json()
+	if err != nil {
+		return "", err
+	}
+	return attestation.CreateMessageAttestation(pgpSigningKey.PublicKey, pgpSigningKey.PrivateKey, hostStr)
 }

--- a/pkg/kritis/util/util_test.go
+++ b/pkg/kritis/util/util_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package util
+
+import (
+	"testing"
+
+	"github.com/grafeas/kritis/pkg/kritis/secrets"
+	"github.com/grafeas/kritis/pkg/kritis/testutil"
+)
+
+func TestCreateAttestationSignature(t *testing.T) {
+	var tests = []struct {
+		name      string
+		image     string
+		shouldErr bool
+	}{
+		{
+			name:      "GoodImage",
+			image:     "gcr.io/kritis-project/kritis-server@sha256:b3f3eccfd27c9864312af3796067e7db28007a1566e1e042c5862eed3ff1b2c8",
+			shouldErr: false,
+		},
+		{
+			name:      "BadImage",
+			image:     "gcr.io/kritis-project/kritis-server:tag",
+			shouldErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pub, priv := testutil.CreateBase64KeyPair(t)
+			secret := secrets.PgpSigningSecret{
+				PrivateKey: priv,
+				PublicKey:  pub,
+				SecretName: "test",
+			}
+			_, err := CreateAttestationSignature(test.image, &secret)
+			testutil.CheckError(t, test.shouldErr, err)
+		})
+	}
+}


### PR DESCRIPTION
In this PR, 

Refactor some code and add logic to create an Attestation Occurrence.
The attestation Occurrence is created as follows:
1. For AttestationAuthority:
```
apiVersion: kritis.github.com/v1beta1
kind: AttestationAuthority
metadata:
    name: test-aa-note 
    namespace: test
spec:
    noteReference: testv1/projects/kritis-int-test 
    privateKeySecretName: test
    publicKeyData: <...>
```
2. AttestationAuthority Note Created
```
name:"projects/kritis-int-test/notes/test-aa-note" 
short_description:"Image Policy Security Attestor" 
long_description:"Image Policy Security Attestor deployed in  namespace test" 
kind:ATTESTATION_AUTHORITY 
attestation_authority:<hint:<human_readable_name:"test-aa-note"> > 
create_time:<seconds:1532461438 nanos:498602000 > 
update_time:<seconds:1532461438 nanos:498602000 > 
```

2. Occurrence Created is:
```
name:"projects/kritis-int-test/occurrences/ee1e2ac4-6ffb-4e0d-8c74-bec31c1610cb" 
resource_url:"https://gcr.io/kritis-int-test/test-
image@sha256:3e2e946cb834c4538b789312d566eb16f4a27734fc6b140a3b3f85baafce965f" 
note_name:"projects/kritis-int-test/notes/test-aa-note" 
kind:ATTESTATION_AUTHORITY
attestation:
      <pgp_signed_attestation:
          <signature:"...." 
          pgp_key_id:"test" 
         > 
    > 
create_time:<seconds:1532461439 nanos:468761000 > 
update_time:<seconds:1532461439 nanos:468761000 > 
```
/cc + @wteiken
Please review the note name and occurrence name,
