### PR TITLE
Swtich to glog for admission controller and cron job.

### DIFF
--- a/cmd/kritis/admission/main.go
+++ b/cmd/kritis/admission/main.go
@@ -25,8 +25,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
+	"github.com/golang/glog"
 	"github.com/grafeas/kritis/cmd/kritis/version"
 	"github.com/grafeas/kritis/pkg/kritis/admission"
 	"github.com/grafeas/kritis/pkg/kritis/cron"
@@ -55,21 +54,21 @@ func main() {
 	flag.StringVar(&cronInterval, "cron-interval", "1h", "Cron Job time interval as Duration e.g. 1h, 2s")
 	flag.Parse()
 
-	// Kick off back ground cron job.
 	if showVersion {
 		fmt.Println(version.Commit)
 		os.Exit(0)
 	}
 
+	// Kick off back ground cron job.
 	if err := StartCronJob(); err != nil {
-		logrus.Fatal(errors.Wrap(err, "starting background job"))
+		glog.Fatal(errors.Wrap(err, "starting background job"))
 	}
 
 	// Start the Kritis Server.
-	logrus.Println("Running the server")
+	glog.Info("Running the server")
 	http.HandleFunc("/", admission.AdmissionReviewHandler)
 	httpsServer := NewServer(Addr)
-	logrus.Fatal(httpsServer.ListenAndServeTLS(tlsCertFile, tlsKeyFile))
+	glog.Fatal(httpsServer.ListenAndServeTLS(tlsCertFile, tlsKeyFile))
 }
 
 func NewServer(addr string) *http.Server {

--- a/kritis-charts/README.md
+++ b/kritis-charts/README.md
@@ -26,10 +26,10 @@ You will need to create a Kubernetes secret, which will provide kritis with the 
 To create the secret:
 1. Create a service account with `Container Analysis Notes Viewer`, `Container Analysis Notes Editor`, `Container Analysis Occurrences Viewer`, and `Container Analysis Occurrences Editor` permissions in the Google Cloud Console project that hosts the images kritis will be inspecting
 2. Download a JSON key for the service account
-3. Rename the key to `kritis.json`
+3. Rename the key to `gac.json`
 4. Create a Kubernetes secret by running:
 ```
-kubectl create secret generic gac-secret --from-file=<path to kritis.json>
+kubectl create secret generic gac-secret --from-file=<path to gac.json>
 ```
 
 #### Creating Container Analysis Secret via Command Line
@@ -42,12 +42,12 @@ The project id can be found from `gcloud config list project`.
 
 2. Create a key for the service account
 ```
-gcloud iam service-accounts keys create ~/kritis.json --iam-account=ACC_NAME@PROJECT_ID.iam.gserviceaccount.com
+gcloud iam service-accounts keys create ~/gac.json --iam-account=ACC_NAME@PROJECT_ID.iam.gserviceaccount.com
 ```
 
 3. Create a kubernetes secret for the service account
 ```
-kubectl create secret generic <SECRET NAME> --from-file=~/kritis.json
+kubectl create secret generic <SECRET NAME> --from-file=~/gac.json
 ```
 
 3. Create policy bindings for the necessary roles:

--- a/pkg/kritis/admission/admission.go
+++ b/pkg/kritis/admission/admission.go
@@ -22,8 +22,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/sirupsen/logrus"
-
+	"github.com/golang/glog"
 	"github.com/grafeas/kritis/cmd/kritis/version"
 	"github.com/grafeas/kritis/pkg/kritis/admission/constants"
 	kritisv1beta1 "github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
@@ -62,16 +61,16 @@ var (
 // If one is not found, it validates against image security policies
 // TODO: Check for attestations
 func AdmissionReviewHandler(w http.ResponseWriter, r *http.Request) {
-	logrus.Info("Starting admission review handler version %s ...", version.Commit)
+	glog.Info("Starting admission review handler version %s ...", version.Commit)
 	pod, err := admissionConfig.retrievePod(r)
 	if err != nil {
-		logrus.Error(err)
+		glog.Error(err)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	// First, check for a breakglass annotation on the pod
 	if checkBreakglass(pod) {
-		logrus.Debugf("found breakglass annotation, returning successful status")
+		glog.Infof("found breakglass annotation, returning successful status")
 		returnStatus(constants.SuccessStatus, constants.SuccessMessage, w)
 		return
 	}
@@ -79,28 +78,28 @@ func AdmissionReviewHandler(w http.ResponseWriter, r *http.Request) {
 	// TODO: Fetch Attestations for the given images to see if the image is already verified
 	images := pods.Images(*pod)
 	if util.CheckGlobalWhitelist(images) {
-		logrus.Debugf("%s are all whitelisted, returning successful status", images)
+		glog.Infof("%s are all whitelisted, returning successful status", images)
 		returnStatus(constants.SuccessStatus, constants.SuccessMessage, w)
 		return
 	}
 	// Next, validate images in the pod against ImageSecurityPolicies in the same namespace
 	isps, err := admissionConfig.fetchImageSecurityPolicies(pod.Namespace)
 	if err != nil {
-		logrus.Errorf("error getting image security policies: %v", err)
+		glog.Errorf("error getting image security policies: %v", err)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	logrus.Debugf("Got isps %v", isps)
+	glog.Infof("Got isps %v", isps)
 	// get the client we will get vulnz from
 	metadataClient, err := admissionConfig.fetchMetadataClient()
 	if err != nil {
-		logrus.Errorf("error getting metadata client: %v", err)
+		glog.Errorf("error getting metadata client: %v", err)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	for _, isp := range isps {
 		for _, image := range images {
-			logrus.Infof("Getting vulnz for %s", image)
+			glog.Infof("Getting vulnz for %s", image)
 			violations, err := admissionConfig.validateImageSecurityPolicy(isp, image, metadataClient)
 			if err != nil {
 				w.WriteHeader(http.StatusBadRequest)
@@ -109,7 +108,7 @@ func AdmissionReviewHandler(w http.ResponseWriter, r *http.Request) {
 			// Check if one of the violations is that the image is not fully qualified
 			for _, v := range violations {
 				if v.Violation == securitypolicy.UnqualifiedImageViolation {
-					logrus.Infof("%s is not a fully qualified image", image)
+					glog.Infof("%s is not a fully qualified image", image)
 					returnStatus(constants.FailureStatus, fmt.Sprintf("%s is not a fully qualified image", image), w)
 					return
 				}
@@ -165,7 +164,7 @@ func returnStatus(status constants.Status, message string, w http.ResponseWriter
 		},
 	}
 	if err := writeHttpResponse(response, w); err != nil {
-		logrus.Error("error writing response:", err)
+		glog.Error("error writing response:", err)
 	}
 }
 
@@ -175,7 +174,7 @@ func writeHttpResponse(response *v1beta1.AdmissionResponse, w http.ResponseWrite
 	}
 	data, err := json.Marshal(ar)
 	if err != nil {
-		logrus.Error(err)
+		glog.Error(err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return nil
 	}

--- a/pkg/kritis/cron/cron.go
+++ b/pkg/kritis/cron/cron.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/grafeas/kritis/pkg/kritis/pods"
 
 	"github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
@@ -28,8 +29,6 @@ import (
 	"github.com/grafeas/kritis/pkg/kritis/violation"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/sirupsen/logrus"
 )
 
 // For testing
@@ -73,15 +72,16 @@ func Start(ctx context.Context, cfg Config, checkInterval time.Duration) {
 	done := ctx.Done()
 
 	for {
+		glog.Info("Checking pods.")
 		select {
 		case <-c.C:
 			isps, err := cfg.SecurityPolicyLister("")
 			if err != nil {
-				logrus.Errorf("fetching image security policies: %s", err)
+				glog.Errorf("fetching image security policies: %s", err)
 				continue
 			}
 			if err := podChecker(cfg, isps); err != nil {
-				logrus.Errorf("error checking pods: %s", err)
+				glog.Errorf("error checking pods: %s", err)
 			}
 		case <-done:
 			return
@@ -104,7 +104,7 @@ func CheckPods(cfg Config, isps []v1beta1.ImageSecurityPolicy) error {
 				}
 				if len(v) != 0 {
 					if err := cfg.ViolationStrategy.HandleViolation(c, &p, v); err != nil {
-						logrus.Errorf("handling violations: %s", err)
+						glog.Errorf("handling violations: %s", err)
 					}
 				}
 			}

--- a/pkg/kritis/util/whitelist.go
+++ b/pkg/kritis/util/whitelist.go
@@ -17,10 +17,11 @@ limitations under the License.
 package util
 
 import (
+	"reflect"
+
+	"github.com/golang/glog"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/grafeas/kritis/pkg/kritis/constants"
-	"github.com/sirupsen/logrus"
-	"reflect"
 )
 
 // CheckGlobalWhitelist returns true if all images are globally whitelisted
@@ -28,7 +29,7 @@ func CheckGlobalWhitelist(images []string) bool {
 	for _, image := range images {
 		whitelisted, err := imageInWhitelist(image)
 		if err != nil {
-			logrus.Errorf("couldn't check if %s is in global whitelist: %v", image, err)
+			glog.Errorf("couldn't check if %s is in global whitelist: %v", image, err)
 		}
 		if !whitelisted {
 			return false

--- a/pkg/kritis/violation/strategy.go
+++ b/pkg/kritis/violation/strategy.go
@@ -16,10 +16,12 @@ limitations under the License.
 package violation
 
 import (
+	"fmt"
+
+	"github.com/golang/glog"
 	"github.com/grafeas/kritis/pkg/kritis/constants"
 	"github.com/grafeas/kritis/pkg/kritis/crd/securitypolicy"
 	"github.com/grafeas/kritis/pkg/kritis/pods"
-	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 )
 
@@ -31,13 +33,12 @@ type LoggingStrategy struct {
 }
 
 func (l *LoggingStrategy) HandleViolation(image string, pod *v1.Pod, violations []securitypolicy.SecurityPolicyViolation) error {
-	logrus.Debug("HandleViolation via LoggingStrategy")
 	if len(violations) == 0 {
 		return nil
 	}
-	logrus.Warnf("Found violations in pod %s, ns %s", pod.Name, pod.Namespace)
+	glog.Warning("Found violations in pod %s, ns %s", pod.Name, pod.Namespace)
 	for _, v := range violations {
-		logrus.Warn(v.Reason)
+		glog.Warning(v.Reason)
 	}
 	return nil
 }
@@ -47,7 +48,6 @@ type AnnotationStrategy struct {
 }
 
 func (a *AnnotationStrategy) HandleViolation(image string, pod *v1.Pod, violations []securitypolicy.SecurityPolicyViolation) error {
-	logrus.Debug("HandleViolation via AnnotationStrategy")
 	// First, remove "kritis.grafeas.io/invalidImageSecPolicy" label/annotation in case it doesn't apply anymore
 	if err := pods.DeleteLabelsAndAnnotations(*pod, []string{constants.InvalidImageSecPolicy}, []string{constants.InvalidImageSecPolicy}); err != nil {
 		return err
@@ -66,7 +66,7 @@ func (a *AnnotationStrategy) HandleViolation(image string, pod *v1.Pod, violatio
 	}
 	labels := map[string]string{constants.InvalidImageSecPolicy: labelValue}
 	annotations := map[string]string{constants.InvalidImageSecPolicy: annotationValue}
-
+	glog.Info(fmt.Sprintf("Adding label %s and annotation %s", labelValue, annotationValue))
 	return pods.AddLabelsAndAnnotations(*pod, labels, annotations)
 }
 


### PR DESCRIPTION
Since we use --logtostderr flag for kritis server, switch to glog for cron as well admission controller.
logrus is still used to integration test and functions using the intergration tests.
