### PR TITLE
Another refactor to make sure we are using the same function to validate policies in cron job and admission controller

### DIFF
--- a/pkg/kritis/admission/admission.go
+++ b/pkg/kritis/admission/admission.go
@@ -52,11 +52,10 @@ type config struct {
 var (
 	// For testing
 	admissionConfig = config{
-		retrievePod:                 unmarshalPod,
-		retrieveDeployment:          unmarshalDeployment,
-		fetchMetadataClient:         metadataClient,
-		fetchImageSecurityPolicies:  securitypolicy.ImageSecurityPolicies,
-		validateImageSecurityPolicy: securitypolicy.ValidateImageSecurityPolicy,
+		retrievePod:                unmarshalPod,
+		retrieveDeployment:         unmarshalDeployment,
+		fetchMetadataClient:        metadataClient,
+		fetchImageSecurityPolicies: securitypolicy.ImageSecurityPolicies,
 	}
 
 	defaultViolationStrategy = violation.LoggingStrategy{}
@@ -173,7 +172,7 @@ func createDeniedResponse(ar *v1beta1.AdmissionReview, message string) {
 func reviewImages(images []string, ns string, ar *v1beta1.AdmissionReview) {
 	images = util.RemoveGloballyWhitelistedImages(images)
 	if len(images) == 0 {
-		glog.Infof("images are all globally whitelisted, returning successful status", images)
+		glog.Info("images are all globally whitelisted, returning successful status")
 		return
 	}
 	// Validate images in the pod against ImageSecurityPolicies in the same namespace

--- a/pkg/kritis/admission/admission.go
+++ b/pkg/kritis/admission/admission.go
@@ -183,7 +183,7 @@ func reviewImages(images []string, ns string, pod *v1.Pod, ar *v1beta1.Admission
 		createDeniedResponse(ar, errMsg)
 		return
 	}
-	r := review.New(client, defaultViolationStrategy)
+	r := review.New(client, defaultViolationStrategy, securitypolicy.ValidateImageSecurityPolicy)
 
 	glog.Infof("Got isps %v", isps)
 	if err := r.Review(images, isps, pod); err != nil {

--- a/pkg/kritis/admission/admission_test.go
+++ b/pkg/kritis/admission/admission_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/grafeas/kritis/cmd/kritis/version"
 	"github.com/grafeas/kritis/pkg/kritis/admission/constants"
 	kritisv1beta1 "github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
-	"github.com/grafeas/kritis/pkg/kritis/crd/securitypolicy"
 	"github.com/grafeas/kritis/pkg/kritis/metadata"
 	"github.com/grafeas/kritis/pkg/kritis/testutil"
 	"k8s.io/api/admission/v1beta1"
@@ -80,10 +79,9 @@ func Test_UnqualifiedImage(t *testing.T) {
 	}
 
 	mockConfig := config{
-		retrievePod:                 mockPod,
-		fetchMetadataClient:         testutil.EmptyMockMetadata(),
-		fetchImageSecurityPolicies:  mockISP,
-		validateImageSecurityPolicy: securitypolicy.ValidateImageSecurityPolicy,
+		retrievePod:                mockPod,
+		fetchMetadataClient:        testutil.NilFetcher(),
+		fetchImageSecurityPolicies: mockISP,
 	}
 	RunTest(t, testConfig{
 		mockConfig: mockConfig,
@@ -108,10 +106,9 @@ func Test_ValidISP(t *testing.T) {
 		}, nil
 	}
 	mockConfig := config{
-		retrievePod:                 mockValidPod(),
-		fetchMetadataClient:         testutil.EmptyMockMetadata(),
-		fetchImageSecurityPolicies:  mockISP,
-		validateImageSecurityPolicy: securitypolicy.ValidateImageSecurityPolicy,
+		retrievePod:                mockValidPod(),
+		fetchMetadataClient:        testutil.NilFetcher(),
+		fetchImageSecurityPolicies: mockISP,
 	}
 	RunTest(t, testConfig{
 		mockConfig: mockConfig,
@@ -148,10 +145,9 @@ func Test_InvalidISP(t *testing.T) {
 		}, nil
 	}
 	mockConfig := config{
-		retrievePod:                 mockValidPod(),
-		fetchMetadataClient:         mockMetadata,
-		fetchImageSecurityPolicies:  mockISP,
-		validateImageSecurityPolicy: securitypolicy.ValidateImageSecurityPolicy,
+		retrievePod:                mockValidPod(),
+		fetchMetadataClient:        mockMetadata,
+		fetchImageSecurityPolicies: mockISP,
 	}
 	RunTest(t, testConfig{
 		mockConfig: mockConfig,

--- a/pkg/kritis/admission/admission_test.go
+++ b/pkg/kritis/admission/admission_test.go
@@ -164,7 +164,7 @@ func Test_GlobalWhitelist(t *testing.T) {
 	mockISP := func(namespace string) ([]kritisv1beta1.ImageSecurityPolicy, error) {
 		return []kritisv1beta1.ImageSecurityPolicy{{
 			Spec: kritisv1beta1.ImageSecurityPolicySpec{
-				PackageVulernerabilityRequirements: kritisv1beta1.PackageVulernerabilityRequirements{
+				PackageVulnerabilityRequirements: kritisv1beta1.PackageVulnerabilityRequirements{
 					MaximumSeverity: "LOW",
 				},
 			},

--- a/pkg/kritis/crd/securitypolicy/securitypolicy.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy.go
@@ -29,6 +29,9 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+// ValidateFunc defines the type for Validating Imagbe Security Polices
+type ValidateFunc func(isp v1beta1.ImageSecurityPolicy, image string, client metadata.MetadataFetcher) ([]SecurityPolicyViolation, error)
+
 // ImageSecurityPolicies returns all ISP's in the specified namespaces
 // Pass in an empty string to get all ISPs in all namespaces
 func ImageSecurityPolicies(namespace string) ([]v1beta1.ImageSecurityPolicy, error) {

--- a/pkg/kritis/crd/securitypolicy/securitypolicy.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// ValidateFunc defines the type for Validating Imagbe Security Polices
+// ValidateFunc defines the type for Validating Image Security Policies
 type ValidateFunc func(isp v1beta1.ImageSecurityPolicy, image string, client metadata.MetadataFetcher) ([]SecurityPolicyViolation, error)
 
 // ImageSecurityPolicies returns all ISP's in the specified namespaces

--- a/pkg/kritis/cron/cron_test.go
+++ b/pkg/kritis/cron/cron_test.go
@@ -18,19 +18,16 @@ package cron
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
-	"github.com/grafeas/kritis/pkg/kritis/crd/securitypolicy"
-
-	"github.com/grafeas/kritis/pkg/kritis/violation"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"k8s.io/api/core/v1"
-
 	"github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
+	"github.com/grafeas/kritis/pkg/kritis/crd/securitypolicy"
 	"github.com/grafeas/kritis/pkg/kritis/metadata"
+	"github.com/grafeas/kritis/pkg/kritis/violation"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestStartCancels(t *testing.T) {
@@ -71,7 +68,9 @@ type imageViolations struct {
 	imageMap map[string]bool
 }
 
-func (iv *imageViolations) violationChecker(image string, isp v1beta1.ImageSecurityPolicy) ([]securitypolicy.SecurityPolicyViolation, error) {
+func (iv *imageViolations) violationChecker(isp v1beta1.ImageSecurityPolicy, image string, client metadata.MetadataFetcher) ([]securitypolicy.SecurityPolicyViolation, error) {
+	fmt.Println(image)
+	fmt.Println(isp)
 	if ok := iv.imageMap[image]; ok {
 		return []securitypolicy.SecurityPolicyViolation{
 			{
@@ -189,11 +188,11 @@ func TestCheckPods(t *testing.T) {
 		tt.args.cfg.ViolationStrategy = &th
 		t.Run(tt.name, func(t *testing.T) {
 			if err := CheckPods(tt.args.cfg, tt.args.isps); err != nil {
-				t.Errorf("CheckPods() error = %v", err)
+				t.Fatalf("CheckPods() error = %v", err)
 			}
 		})
 		if (len(th.Violations) != 0) != tt.wantViolations {
-			t.Errorf("got violations %v, expected to have %v", th.Violations, tt.wantViolations)
+			t.Fatalf("got violations %v, expected to have %v", th.Violations, tt.wantViolations)
 		}
 	}
 }

--- a/pkg/kritis/cron/cron_test.go
+++ b/pkg/kritis/cron/cron_test.go
@@ -18,7 +18,6 @@ package cron
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -69,8 +68,6 @@ type imageViolations struct {
 }
 
 func (iv *imageViolations) violationChecker(isp v1beta1.ImageSecurityPolicy, image string, client metadata.MetadataFetcher) ([]securitypolicy.SecurityPolicyViolation, error) {
-	fmt.Println(image)
-	fmt.Println(isp)
 	if ok := iv.imageMap[image]; ok {
 		return []securitypolicy.SecurityPolicyViolation{
 			{

--- a/pkg/kritis/review/review.go
+++ b/pkg/kritis/review/review.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package review
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
+	"github.com/grafeas/kritis/pkg/kritis/crd/securitypolicy"
+	"github.com/grafeas/kritis/pkg/kritis/metadata"
+	"github.com/grafeas/kritis/pkg/kritis/util"
+	"github.com/grafeas/kritis/pkg/kritis/violation"
+	"k8s.io/api/core/v1"
+)
+
+type Reviewer struct {
+	client   metadata.MetadataFetcher
+	vs       violation.Strategy
+	validate securitypolicy.ValidateFunc
+}
+
+func New(client metadata.MetadataFetcher, vs violation.Strategy, validate securitypolicy.ValidateFunc) Reviewer {
+	return Reviewer{
+		client:   client,
+		vs:       vs,
+		validate: validate,
+	}
+}
+
+// Review reviews a given images against ImageSecurityPolicies and return error
+// if voilations are found and handles violation as per violation strategy
+// Returns error if violations are present.
+func (r Reviewer) Review(images []string, isps []v1beta1.ImageSecurityPolicy, pod *v1.Pod) error {
+	images = util.RemoveGloballyWhitelistedImages(images)
+	if len(images) == 0 {
+		glog.Info("images are all globally whitelisted, returning successful status", images)
+		return nil
+	}
+	for _, isp := range isps {
+		for _, image := range images {
+			glog.Infof("Getting vulnz for %s", image)
+			violations, err := r.validate(isp, image, r.client)
+			if err != nil {
+				return fmt.Errorf("error validating image security policy %v", err)
+			}
+			if len(violations) != 0 {
+				errMsg := fmt.Sprintf("found violations in %s", image)
+				// Check if one of the violations is that the image is not fully qualified
+				for _, v := range violations {
+					if v.Violation == securitypolicy.UnqualifiedImageViolation {
+						errMsg = fmt.Sprintf("%s is not a fully qualified image", image)
+					}
+				}
+				if err := r.vs.HandleViolation(image, pod, violations); err != nil {
+					return fmt.Errorf("%s. error handling voilation %v", errMsg, err)
+				}
+				return fmt.Errorf(errMsg)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/kritis/review/review.go
+++ b/pkg/kritis/review/review.go
@@ -42,9 +42,8 @@ func New(client metadata.MetadataFetcher, vs violation.Strategy, validate securi
 	}
 }
 
-// Review reviews a given images against ImageSecurityPolicies and return error
-// if voilations are found and handles violation as per violation strategy
-// Returns error if violations are present.
+// Review reviews a set of images against a set of policies
+// Returns error if violations are found and handles them as per violation strategy
 func (r Reviewer) Review(images []string, isps []v1beta1.ImageSecurityPolicy, pod *v1.Pod) error {
 	images = util.RemoveGloballyWhitelistedImages(images)
 	if len(images) == 0 {
@@ -67,7 +66,7 @@ func (r Reviewer) Review(images []string, isps []v1beta1.ImageSecurityPolicy, po
 					}
 				}
 				if err := r.vs.HandleViolation(image, pod, violations); err != nil {
-					return fmt.Errorf("%s. error handling voilation %v", errMsg, err)
+					return fmt.Errorf("%s. error handling violation %v", errMsg, err)
 				}
 				return fmt.Errorf(errMsg)
 			}

--- a/pkg/kritis/testutil/metadata_mock.go
+++ b/pkg/kritis/testutil/metadata_mock.go
@@ -46,7 +46,7 @@ func (m MockMetadataClient) GetAttestations(containerImage string) ([]metadata.P
 	return m.PGPAttestations, nil
 }
 
-func EmptyMockMetadata() func() (metadata.MetadataFetcher, error) {
+func NilFetcher() func() (metadata.MetadataFetcher, error) {
 	return func() (metadata.MetadataFetcher, error) {
 		return nil, nil
 	}

--- a/pkg/kritis/violation/strategy.go
+++ b/pkg/kritis/violation/strategy.go
@@ -32,12 +32,12 @@ type Strategy interface {
 type LoggingStrategy struct {
 }
 
-func (l *LoggingStrategy) HandleViolation(image string, ns string, violations []securitypolicy.SecurityPolicyViolation) error {
+func (l *LoggingStrategy) HandleViolation(image string, pod *v1.Pod, violations []securitypolicy.SecurityPolicyViolation) error {
 	glog.Info("HandleViolation via LoggingStrategy")
 	if len(violations) == 0 {
 		return nil
 	}
-	glog.Warningf("Found violations in image %s, ns %s", image, ns)
+	glog.Warningf("Found violations in image %s, ns %s", image, pod.Namespace)
 	for _, v := range violations {
 		glog.Warning(v.Reason)
 	}
@@ -78,5 +78,6 @@ type MemoryStrategy struct {
 
 func (ms *MemoryStrategy) HandleViolation(image string, p *v1.Pod, v []securitypolicy.SecurityPolicyViolation) error {
 	ms.Violations[image] = true
+	fmt.Println("called", ms)
 	return nil
 }

--- a/pkg/kritis/violation/strategy.go
+++ b/pkg/kritis/violation/strategy.go
@@ -78,6 +78,5 @@ type MemoryStrategy struct {
 
 func (ms *MemoryStrategy) HandleViolation(image string, p *v1.Pod, v []securitypolicy.SecurityPolicyViolation) error {
 	ms.Violations[image] = true
-	fmt.Println("called", ms)
 	return nil
 }


### PR DESCRIPTION
We need to attest pods in Cron job as well as Admission controller.
I realized we do not use the same function to review policies in cron and admission controller. 
I was doing the same thing twice and hence the refactor.
This refactor, 
-  Move the review function from admission.reviewImages to its own package.
- Added a todo to move the tests pertaining to review.Review to review_test.go.
- Both admission and cron job use the same function.