### PR TITLE
Catch invalid thresholds and make vulnerabilities programmable by the test.

### DIFF
--- a/pkg/kritis/crd/securitypolicy/securitypolicy.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy.go
@@ -124,12 +124,10 @@ func severityWithinThreshold(maxSeverity string, severity string) (error, bool) 
 	if maxSeverity == constants.BLOCKALL {
 		return nil, false
 	}
-	_, ok := ca.VulnerabilityType_Severity_value[maxSeverity]
-	if !ok {
+	if _, ok := ca.VulnerabilityType_Severity_value[maxSeverity]; !ok {
 		return fmt.Errorf("invalid maximum severity level: %s", maxSeverity), false
 	}
-	_, ok = ca.VulnerabilityType_Severity_value[severity]
-	if !ok {
+	if _, ok := ca.VulnerabilityType_Severity_value[severity]; !ok {
 		return fmt.Errorf("invalid severity level: %s", severity), false
 	}
 	return nil, ca.VulnerabilityType_Severity_value[severity] <= ca.VulnerabilityType_Severity_value[maxSeverity]

--- a/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
@@ -276,7 +276,7 @@ func Test_severityWithinThreshold(t *testing.T) {
 			expected:    true,
 		},
 		{
-			name:        "test bloackall max severity",
+			name:        "test blockall max severity",
 			maxSeverity: "BLOCKALL",
 			severity:    "LOW",
 			expected:    false,


### PR DESCRIPTION
This is to prepare for making adjustments to how OnlyFixesNotAvailable are handled,
but in general the adjustments are influenced by the following guidelines:

- The test should be so simple as to be correct by inspection
- Readers should need to read only the test body to understand the test
- Tests should never rely on default values specified by a helper method

severityWithinThreshold() now takes two strings instead of an isp and a
string, to both reduce unnecessary coupling (Law of Demeter), and simplify test setup.