### PR TITLE
Release resolve-tags plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+PWD = $(shell pwd)
 GOOS ?= $(shell go env GOOS)
 GOARCH = amd64
 BUILD_DIR ?= ./out
@@ -34,7 +35,8 @@ RESOLVE_TAGS_PROJECT := resolve-tags
 REPOPATH ?= $(ORG)/$(PROJECT)
 
 SUPPORTED_PLATFORMS := linux-$(GOARCH) darwin-$(GOARCH) windows-$(GOARCH).exe
-RESOLVE_TAGS_PACKAGE = $(REPOPATH)/cmd/kritis/kubectl/plugins/resolve
+RESOLVE_TAGS_PATH = cmd/kritis/kubectl/plugins/resolve
+RESOLVE_TAGS_PACKAGE = $(REPOPATH)/$(RESOLVE_TAGS_PATH)
 RESOLVE_TAGS_KUBECTL_DIR = ~/.kube/plugins/resolve-tags
 
 LOCAL_GAC_CREDENTIALS_PATH=/tmp/gac.json
@@ -61,6 +63,12 @@ cross: $(foreach platform, $(SUPPORTED_PLATFORMS), $(BUILD_DIR)/$(RESOLVE_TAGS_P
 
 $(BUILD_DIR)/$(RESOLVE_TAGS_PROJECT)-%-$(GOARCH): $(GO_FILES) $(BUILD_DIR)
 	GOOS=$* GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags $(GO_LD_RESOLVE_FLAGS) -tags $(GO_BUILD_TAGS) -o $@ $(RESOLVE_TAGS_PACKAGE)
+
+.PHONY: cross-tar
+cross-tar: $(foreach platform, $(SUPPORTED_PLATFORMS), $(BUILD_DIR)/$(RESOLVE_TAGS_PROJECT)-$(platform).tar)
+
+$(BUILD_DIR)/$(RESOLVE_TAGS_PROJECT)-%.tar: cross
+	tar -cf $@ -C $(RESOLVE_TAGS_PATH) plugin.yaml -C $(PWD)/out/ resolve-tags-$*
 
 .PHONY: install-plugin
 install-plugin: $(BUILD_DIR)/$(RESOLVE_TAGS_PROJECT)

--- a/cmd/kritis/kubectl/plugins/resolve/README.md
+++ b/cmd/kritis/kubectl/plugins/resolve/README.md
@@ -27,7 +27,7 @@ sudo cp $RESOLVE_TAGS_DIR/resolve-tags /usr/local/bin/
 ```
 
 ## Quickstart
-=
+
 ### Running the resolve-tags kubectl plugin
 
 You can run the plugin as follows:

--- a/cmd/kritis/kubectl/plugins/resolve/README.md
+++ b/cmd/kritis/kubectl/plugins/resolve/README.md
@@ -9,21 +9,20 @@ It can be run as a binary or installed as a kubectl plugin.
 
 ```shell
 curl -LO https://storage.googleapis.com/resolve-tags/latest/resolve-tags-darwin-amd64.tar && \
-RESOLVE_TAGS_DIR=$HOME/.kube/plugins/resolve && \
-mkdir -p $RESOLVE_TAGS_DIR && tar -C $RESOLVE_TAGS_DIR -xf resolve-tags-darwin-amd64.tar && \
-mv $RESOLVE_TAGS_DIR/resolve-tags-darwin-amd64 $RESOLVE_TAGS_DIR/resolve-tags && \
-sudo cp $RESOLVE_TAGS_DIR/resolve-tags /usr/local/bin/
+  RESOLVE_TAGS_DIR=$HOME/.kube/plugins/resolve && \
+  mkdir -p $RESOLVE_TAGS_DIR && tar -C $RESOLVE_TAGS_DIR -xf resolve-tags-darwin-amd64.tar && \
+  mv $RESOLVE_TAGS_DIR/resolve-tags-darwin-amd64 $RESOLVE_TAGS_DIR/resolve-tags && \
+  sudo cp $RESOLVE_TAGS_DIR/resolve-tags /usr/local/bin/
 ```
 
 ## Linux
 
 ```shell
-
-curl -LO https://storage.googleapis.com/resolve-tags/latest/resolve-tags-linux-amd64.tar curl  && \
-RESOLVE_TAGS_DIR=$HOME/.kube/plugins/resolve && \
-mkdir -p $RESOLVE_TAGS_DIR && tar -C $RESOLVE_TAGS_DIR -xf resolve-tags-linux-amd64.tar && \
-mv $RESOLVE_TAGS_DIR/resolve-tags-linux-amd64 $RESOLVE_TAGS_DIR/resolve-tags && \
-sudo cp $RESOLVE_TAGS_DIR/resolve-tags /usr/local/bin/
+curl -LO https://storage.googleapis.com/resolve-tags/latest/resolve-tags-linux-amd64.tar && \
+  RESOLVE_TAGS_DIR=$HOME/.kube/plugins/resolve && \
+  mkdir -p $RESOLVE_TAGS_DIR && tar -C $RESOLVE_TAGS_DIR -xf resolve-tags-linux-amd64.tar && \
+  mv $RESOLVE_TAGS_DIR/resolve-tags-linux-amd64 $RESOLVE_TAGS_DIR/resolve-tags && \
+  sudo cp $RESOLVE_TAGS_DIR/resolve-tags /usr/local/bin/
 ```
 
 ## Quickstart

--- a/cmd/kritis/kubectl/plugins/resolve/README.md
+++ b/cmd/kritis/kubectl/plugins/resolve/README.md
@@ -3,46 +3,57 @@
 resolve-tags replaces tagged images in your Kubernetes yamls with their corresponding digests, and prints the new manifest to STDOUT.
 It can be run as a binary or installed as a kubectl plugin.
 
-## kubectl plugin
+## Installation
 
-To install as a kubectl plugin, run:
+## macOS
 
+```shell
+curl -LO https://storage.googleapis.com/resolve-tags/latest/resolve-tags-darwin-amd64.tar && \
+RESOLVE_TAGS_DIR=$HOME/.kube/plugins/resolve && \
+mkdir -p $RESOLVE_TAGS_DIR && tar -C $RESOLVE_TAGS_DIR -xf resolve-tags-darwin-amd64.tar && \
+mv $RESOLVE_TAGS_DIR/resolve-tags-darwin-amd64 $RESOLVE_TAGS_DIR/resolve-tags && \
+sudo cp $RESOLVE_TAGS_DIR/resolve-tags /usr/local/bin/
 ```
-make install-plugin
+
+## Linux
+
+```shell
+
+curl -LO https://storage.googleapis.com/resolve-tags/latest/resolve-tags-linux-amd64.tar curl  && \
+RESOLVE_TAGS_DIR=$HOME/.kube/plugins/resolve && \
+mkdir -p $RESOLVE_TAGS_DIR && tar -C $RESOLVE_TAGS_DIR -xf resolve-tags-linux-amd64.tar && \
+mv $RESOLVE_TAGS_DIR/resolve-tags-linux-amd64 $RESOLVE_TAGS_DIR/resolve-tags && \
+sudo cp $RESOLVE_TAGS_DIR/resolve-tags /usr/local/bin/
 ```
 
-in the top level directory.
+## Quickstart
+=
+### Running the resolve-tags kubectl plugin
 
-You can then run the plugin:
+You can run the plugin as follows:
 
 ```
 kubectl plugin resolve-tags -f <path to file>
 ```
 
-To apply subsitutions using `kubectl apply -f`, you can run:
+To apply subsitutions as you would using `kubectl apply -f`, you can run:
+
 ```
 kubectl plugin resolve-tags -f <path to file> --apply true
 ```
 
-## resolve-tags binary
+Note: The plugin can only resolve one file at a time.
+If you need to resolve more than one file at the time, consider using the binary.
 
-resolve-tags can also be run as a binary.
-This is useful if you want to pass in multiple files at a time.
-To build the binary, run:
+## Running the resolve-tags binary
 
-```
-make out/resolve-tags
-```
-
-in the top level directory.
-
-You can then run the binary:
+You can run the resolve-tags binary as follows:
 
 ```
-./out/resolve-tags -f <path to file> -f <path to another file>
+resolve-tags -f <path to file> -f <path to another file>
 ```
 To apply subsitutions using `kubectl apply -f`, you can run:
 ```
-kubectl plugin resolve-tags -f <path to file> -a
+resolve-tags -f <path to file> -a
 ```
 This will apply the digest to the objects defined in file.

--- a/deploy/cloudbuild-release.yaml
+++ b/deploy/cloudbuild-release.yaml
@@ -25,10 +25,10 @@ steps:
            "-t", "resolve-tags", "."]
   # Do the go build
   - name: "resolve-tags"
-    args: ["make", "out/resolve-tags"]
+    args: ["make", "cross-tar"]
   # Copy over resolve-tags to bucket
   - name: "gcr.io/cloud-builders/gsutil"
-    args: ["cp", "out/resolve-tags", "gs://resolve-tags/$TAG_NAME/"]
+    args: ["cp", "out/resolve-tags*", "gs://resolve-tags/$TAG_NAME/"]
 images: ["gcr.io/kritis-project/kritis-server:$TAG_NAME",
          "gcr.io/kritis-project/preinstall:$TAG_NAME",
          "gcr.io/kritis-project/postinstall:$TAG_NAME",

--- a/deploy/cloudbuild-release.yaml
+++ b/deploy/cloudbuild-release.yaml
@@ -19,7 +19,16 @@ steps:
     args: ["build", "-f", "helm-release/Dockerfile",
            "-t", "gcr.io/kritis-project/helm-release:$TAG_NAME", "."]
   - name: "gcr.io/kritis-project/helm-release:$TAG_NAME"
-
+  # Build container to build resolve-tags
+  - name: "gcr.io/cloud-builders/docker"
+    args: ["build", "-f", "deploy/Dockerfile_resolve",
+           "-t", "resolve-tags", "."]
+  # Do the go build
+  - name: "resolve-tags"
+    args: ["make", "out/resolve-tags"]
+  # Copy over resolve-tags to bucket
+  - name: "gcr.io/cloud-builders/gsutil"
+    args: ["cp", "out/resolve-tags", "gs://resolve-tags/$TAG_NAME/"]
 images: ["gcr.io/kritis-project/kritis-server:$TAG_NAME",
          "gcr.io/kritis-project/preinstall:$TAG_NAME",
          "gcr.io/kritis-project/postinstall:$TAG_NAME",

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -30,10 +30,10 @@ steps:
            "-t", "resolve-tags", "."]
   # Do the go build
   - name: "resolve-tags"
-    args: ["make", "out/resolve-tags"]
+    args: ["make", "cross-tar"]
   # Copy over resolve-tags to bucket
   - name: "gcr.io/cloud-builders/gsutil"
-    args: ["cp", "out/resolve-tags", "gs://resolve-tags/$COMMIT_SHA/"]
+    args: ["cp", "out/resolve-tags*", "gs://resolve-tags/$COMMIT_SHA/"]
   - name: "gcr.io/cloud-builders/gsutil"
     args: ["cp", "gs://resolve-tags/$COMMIT_SHA/*", "gs://resolve-tags/latest/"]
 images: ["gcr.io/kritis-project/kritis-server:${COMMIT_SHA}",


### PR DESCRIPTION
TODO: Add section for installing on Windows

Partially fixes #168 

The kubectl plugin requires the plugin.yaml file and the resolve-tags binary to work. I added a Makefile target `cross-tar` which creates tarballs of these two files for each platform.

The installation command copies the tarball from a bucket, extracts both files to `$HOME/.kube/plugins/resolve`, and then copies the resolve-tags binary into `/usr/local/bin`