### PR TITLE
globally whitelist hook images and fix a bug in the helm chart

### DIFF
--- a/kritis-charts/values.yaml
+++ b/kritis-charts/values.yaml
@@ -41,7 +41,7 @@ clusterRoleBindingName: kritis-clusterrolebinding
 clusterRoleName: kritis-clusterrole
 cronInterval: 1h
 
-repo: gcr.io/kritis-project/
+repository: gcr.io/kritis-project/
 
 # kritis-server-webhook.yaml values
 caBundle: ""

--- a/pkg/kritis/constants/constants.go
+++ b/pkg/kritis/constants/constants.go
@@ -46,5 +46,8 @@ const (
 var (
 	// GlobalImageWhitelist is a list of images that are globally whitelisted
 	// They should always pass the webhook check
-	GlobalImageWhitelist = []string{"gcr.io/kritis-project/kritis-server"}
+	GlobalImageWhitelist = []string{"gcr.io/kritis-project/kritis-server",
+		"gcr.io/kritis-project/preinstall",
+		"gcr.io/kritis-project/postinstall",
+		"gcr.io/kritis-project/predelete"}
 )


### PR DESCRIPTION
Should fix #188 