### PR TITLE
Switch from image tag from v0.0.1 image to latest.

### DIFF
--- a/kritis-charts/values.yaml
+++ b/kritis-charts/values.yaml
@@ -6,7 +6,8 @@ replicaCount: 1
 
 image:
   image: kritis-server
-  tag: v0.0.1
+  # TODO(tstromberg): Have a versioned tag after release.
+  tag: latest
   name: kritis-server
   pullPolicy: Always
 


### PR DESCRIPTION
v0.0.1 is no longer compatible with the changes at head due to a change
in preinstall flags.