### PR TITLE
Remove unnecessary use of ../ as a working directory for exec.Command invocations.

### DIFF
--- a/integration/logs.go
+++ b/integration/logs.go
@@ -25,7 +25,6 @@ import (
 
 func getPodLogs(t *testing.T, pod string, ns *v1.Namespace) string {
 	cmd := exec.Command("kubectl", "logs", pod, "-n", ns.Name)
-	cmd.Dir = "../"
 	output, err := integration_util.RunCmdOut(cmd)
 	if err != nil {
 		t.Errorf("%s: %s %v", pod, output, err)
@@ -36,13 +35,11 @@ func getPodLogs(t *testing.T, pod string, ns *v1.Namespace) string {
 func getKritisLogs(t *testing.T) string {
 	cmd := exec.Command("kubectl", "logs", "-l",
 		"app=kritis-validation-hook")
-	cmd.Dir = "../"
 	output, err := integration_util.RunCmdOut(cmd)
 	if err != nil {
 		t.Fatalf("kritis: %s %v", output, err)
 	}
 	cmd = exec.Command("kubectl", "get", "imagesecuritypolicy")
-	cmd.Dir = "../"
 	output2, err := integration_util.RunCmdOut(cmd)
 	if err != nil {
 		t.Fatalf("kritis: %s %v", output2, err)

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -152,7 +152,6 @@ func initKritis(t *testing.T, ns *v1.Namespace) func() {
 	deleteFunc := func() {
 		// cleanup
 		helmCmd = exec.Command("helm", "delete", "--purge", kritisRelease)
-		helmCmd.Dir = "../"
 		_, err = integration_util.RunCmdOut(helmCmd)
 		if err != nil {
 			deleteObject(t, "validatingwebhookconfiguration",


### PR DESCRIPTION
Addresses lint error:

string `../` has 3 occurrences, make it a constant (goconst)