### PR TITLE
K8 api  return PEM encoded value of secret.

### DIFF
--- a/pkg/kritis/attestation/attestation.go
+++ b/pkg/kritis/attestation/attestation.go
@@ -46,7 +46,7 @@ var pgpConfig = packet.Config{
 	RSABits: constants.RSABits,
 }
 
-// VerifyMessageAttestation verifies if the image is attested using the Base64
+// VerifyMessageAttestation verifies if the image is attested using the PEM
 // encoded public key.
 func VerifyMessageAttestation(pubKey string, attestationHash string, message string) error {
 
@@ -88,12 +88,12 @@ func VerifyMessageAttestation(pubKey string, attestationHash string, message str
 }
 
 // CreateMessageAttestation attests the message using the given public and private key.
-// pubKeyEnc: Base64 Encoded Public Key
-// privKeyEnc: Base64 Decoded Private Key
+// pubKey: PEM Encoded Public Key
+// privKey: PEM Decoded Private Key
 // message: Message to attest
-func CreateMessageAttestation(pubKeyEnc string, privKeyEnc string, message string) (string, error) {
+func CreateMessageAttestation(pubKey string, privKey string, message string) (string, error) {
 	// Create a PgpKey from Encoded Public Key
-	pgpKey, err := NewPgpKey(privKeyEnc, pubKeyEnc)
+	pgpKey, err := NewPgpKey(privKey, pubKey)
 	if err != nil {
 		return "", errors.Wrap(err, "creating PGP key")
 	}

--- a/pkg/kritis/attestation/attestation.go
+++ b/pkg/kritis/attestation/attestation.go
@@ -24,6 +24,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"github.com/grafeas/kritis/pkg/kritis/admission/constants"
 	"github.com/pkg/errors"
@@ -47,18 +48,14 @@ var pgpConfig = packet.Config{
 
 // VerifyMessageAttestation verifies if the image is attested using the Base64
 // encoded public key.
-func VerifyMessageAttestation(pubKeyEnc string, attestationHash string, message string) error {
-	pemPublicKey, err := base64.StdEncoding.DecodeString(pubKeyEnc)
-	if err != nil {
-		return err
-	}
+func VerifyMessageAttestation(pubKey string, attestationHash string, message string) error {
 
 	attestation, err := base64.StdEncoding.DecodeString(attestationHash)
 	if err != nil {
 		return err
 	}
 
-	keyring, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(pemPublicKey))
+	keyring, err := openpgp.ReadArmoredKeyRing(strings.NewReader(pubKey))
 	if err != nil {
 		return err
 	}

--- a/pkg/kritis/attestation/attestation_test.go
+++ b/pkg/kritis/attestation/attestation_test.go
@@ -36,7 +36,7 @@ var tcAttestations = []struct {
 
 func TestAttestations(t *testing.T) {
 	for _, tc := range tcAttestations {
-		publicKey, privateKey := testutil.CreateBase64KeyPair(t, "test")
+		publicKey, privateKey := testutil.CreateKeyPair(t, "test")
 		t.Run(tc.name, func(t *testing.T) {
 			sig, err := CreateMessageAttestation(publicKey, privateKey, tc.message)
 			if err != nil {
@@ -52,7 +52,7 @@ func TestAttestations(t *testing.T) {
 }
 
 func TestGPGArmorSignIntegration(t *testing.T) {
-	if err := VerifyMessageAttestation(testutil.PublicTestKey, base64.StdEncoding.EncodeToString([]byte(expectedSig)), "test"); err != nil {
+	if err := VerifyMessageAttestation(testutil.Base64PublicTestKey(t), base64.StdEncoding.EncodeToString([]byte(expectedSig)), "test"); err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}
 }

--- a/pkg/kritis/attestation/pgpkey.go
+++ b/pkg/kritis/attestation/pgpkey.go
@@ -17,9 +17,8 @@ limitations under the License.
 package attestation
 
 import (
-	"bytes"
-	"encoding/base64"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/openpgp"
@@ -34,7 +33,7 @@ type PgpKey struct {
 	publicKey  *packet.PublicKey
 }
 
-func NewPgpKey(privateKeyEnc string, publicKeyEnc string) (*PgpKey, error) {
+func NewPgpKey(privateKeyStr string, publicKeyStr string) (*PgpKey, error) {
 	var publicKey *packet.PublicKey
 	var privateKey *packet.PrivateKey
 	var err error
@@ -90,11 +89,7 @@ func parsePrivateKey(privateKey string) (*packet.PrivateKey, error) {
 }
 
 func parseKey(key string, keytype string) (packet.Packet, error) {
-	s, err := base64.StdEncoding.DecodeString(key)
-	if err != nil {
-		return nil, err
-	}
-	r := bytes.NewReader(s)
+	r := strings.NewReader(key)
 	block, err := armor.Decode(r)
 	if err != nil {
 		return nil, err

--- a/pkg/kritis/attestation/pgpkey.go
+++ b/pkg/kritis/attestation/pgpkey.go
@@ -38,14 +38,14 @@ func NewPgpKey(privateKeyStr string, publicKeyStr string) (*PgpKey, error) {
 	var privateKey *packet.PrivateKey
 	var err error
 
-	if privateKeyEnc != "" {
-		privateKey, err = parsePrivateKey(privateKeyEnc)
+	if privateKeyStr != "" {
+		privateKey, err = parsePrivateKey(privateKeyStr)
 		if err != nil {
 			return nil, errors.Wrap(err, "parsing private key")
 		}
 	}
-	if publicKeyEnc != "" {
-		publicKey, err = parsePublicKey(publicKeyEnc)
+	if publicKeyStr != "" {
+		publicKey, err = parsePublicKey(publicKeyStr)
 		if err != nil {
 			return nil, errors.Wrap(err, "parsing public key")
 		}

--- a/pkg/kritis/container/container_test.go
+++ b/pkg/kritis/container/container_test.go
@@ -146,7 +146,7 @@ func TestGPGArmorSignVerifyIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error %s", err)
 	}
-	if err := container.VerifyAttestationSignature(testutil.PublicTestKey, expectedSig); err != nil {
+	if err := container.VerifyAttestationSignature(testutil.Base64PublicTestKey(t), expectedSig); err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}
 }

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
@@ -76,7 +76,7 @@ func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
 		t.Fatalf("Expected %s.\n Got %s", expectedNoteName, actualHint)
 	}
 	// Test Create Attestation Occurence
-	pub, priv := testutil.CreateBase64KeyPair(t, "test")
+	pub, priv := testutil.CreateKeyPair(t, "test")
 	secret := &secrets.PGPSigningSecret{
 		PrivateKey: priv,
 		PublicKey:  pub,

--- a/pkg/kritis/testutil/util.go
+++ b/pkg/kritis/testutil/util.go
@@ -77,7 +77,7 @@ func getKey(key *openpgp.Entity, keyType string, t *testing.T) string {
 		CheckError(t, false, key.Serialize(wr))
 	}
 	wr.Close()
-	return string(gotWriter.Bytes())
+	return gotWriter.String()
 }
 
 func CreateSecret(t *testing.T, name string) *secrets.PGPSigningSecret {


### PR DESCRIPTION
kubectl get secret shows base64 encoded value of secret.
However, the k8 api fetches the secret as is without encoding it.
We no longer need to decode the secret to get to the PEM secret value.
Hence change all functions decoding the secret to use it just as is.