### PR TITLE
Add int tests for annotation and delete them

### DIFF
--- a/artifacts/integration-examples/attestation-authority-example.yaml
+++ b/artifacts/integration-examples/attestation-authority-example.yaml
@@ -1,8 +1,0 @@
-apiVersion: kritis.grafeas.io/v1beta1
-kind: AttestationAuthority
-metadata:
-  name: qa-attestor
-spec:
-    noteReference: v1alpha1/projects/image-signing
-    privateKeySecretName: foo
-    publicKeyData: dsfdasfdkla

--- a/integration/attestation.go
+++ b/integration/attestation.go
@@ -21,27 +21,30 @@ import (
 	"github.com/grafeas/kritis/pkg/kritis/metadata/containeranalysis"
 )
 
-func checkAndDeleteAttestations(t *testing.T, images []string) {
+func getAttestations(t *testing.T, images []string) map[string]bool {
 	t.Helper()
+	m := make(map[string]bool, len(images))
 	if len(images) == 0 {
-		return
+		return m
 	}
 	client, err := containeranalysis.NewContainerAnalysisClient()
 	if err != nil {
 		t.Fatalf("Unexpected error while fetching client %v", err)
 	}
+
 	for _, i := range images {
 		occs, err := client.GetAttestations(i)
 		if err != nil {
 			t.Fatalf("Unexpected error while listing attestations for image %s, %v", i, err)
 		}
 		if occs != nil {
-			t.Errorf("expected image %s to be attested. No attestations found.", i)
+			m[i] = true
 		}
 		for _, o := range occs {
-			if err := client.DeleteOccurrence(o.OccName); err != nil {
-				t.Logf("could not delete attestations occurrence %s due to %v", o.OccName, err)
+			if err := client.DeleteOccurrence(o.OccID); err != nil {
+				t.Logf("could not delete attestations occurrence %s due to %v", o.OccID, err)
 			}
 		}
 	}
+	return m
 }

--- a/integration/attestation.go
+++ b/integration/attestation.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package integration
+
+import (
+	"testing"
+
+	"github.com/grafeas/kritis/pkg/kritis/metadata/containeranalysis"
+)
+
+func checkAndDeleteAttestations(t *testing.T, images []string) {
+	t.Helper()
+	if len(images) == 0 {
+		return
+	}
+	client, err := containeranalysis.NewContainerAnalysisClient()
+	if err != nil {
+		t.Fatalf("Unexpected error while fetching client %v", err)
+	}
+	for _, i := range images {
+		occs, err := client.GetAttestations(i)
+		if err != nil {
+			t.Fatalf("Unexpected error while listing attestations for image %s, %v", i, err)
+		}
+		if occs != nil {
+			t.Errorf("expected image %s to be attested. No attestations found.", i)
+		}
+		for _, o := range occs {
+			if err := client.DeleteOccurrence(o.OccName); err != nil {
+				t.Logf("could not delete attestations occurrence %s due to %v", o.OccName, err)
+			}
+		}
+	}
+}

--- a/integration/cleanup.go
+++ b/integration/cleanup.go
@@ -32,6 +32,7 @@ func cleanupKritis(t *testing.T, ns *v1.Namespace) {
 		fmt.Sprintf("kritis-validation-hook-deployments-%s", ns.Name), nil)
 	deleteObject(t, "csr",
 		fmt.Sprintf("tls-webhook-secret-cert-%s", ns.Name), nil)
+	deleteObject(t, "secret", aaSecret, ns)
 }
 
 func deleteObject(t *testing.T, object, name string, ns *v1.Namespace) {

--- a/integration/crd.go
+++ b/integration/crd.go
@@ -37,7 +37,7 @@ kind: AttestationAuthority
 metadata:
   name: test-attestor
 spec:
-  noteReference: v1alpha1/projects/image-signing
+  noteReference: v1alpha1/projects/krits-int-test
   privateKeySecretName: %s
   publicKeyData: %s`
 )

--- a/integration/crd.go
+++ b/integration/crd.go
@@ -53,8 +53,6 @@ var crdNames = map[string]string{
 var crdExamples = []string{
 	"image-security-policy-example.yaml",
 }
-var templateFile = "attestation-authority-example.yaml.template"
-var templateFileSuffix = ".template"
 
 func createAttestationAuthority(t *testing.T, ns string) {
 	t.Helper()
@@ -128,7 +126,7 @@ func createFileWithContents(t *testing.T, d string, c string) string {
 
 func createAA(t *testing.T, ns string, pubkey string) {
 	t.Helper()
-	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd := exec.Command("kubectl", "apply", "-n", ns, "-f", "-")
 	cmd.Stdin = bytes.NewReader([]byte(fmt.Sprintf(testAttesationAuthority, aaSecret, pubkey)))
 	if _, err := integration_util.RunCmdOut(cmd); err != nil {
 		t.Fatalf("testing error: %v", err)

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -164,9 +164,8 @@ func initKritis(t *testing.T, ns *v1.Namespace) func() {
 				fmt.Sprintf("kritis-validation-hook-deployments-%s", ns.Name), nil)
 			deleteObject(t, "csr",
 				fmt.Sprintf("tls-webhook-secret-cert-%s", ns.Name), nil)
-			deleteObject(t, "namespace", ns.Name, nil)
+			deleteObject(t, "secret", aaSecret, ns)
 			t.Fatalf("testing error: %v", err)
-			deleteObject(t, "secret", aaSecret, ns.Name)
 		}
 		// make sure kritis-predelete pod completes
 		if err := kubernetesutil.WaitForPodComplete(client.CoreV1().Pods(ns.Name), kritisPredelete); err != nil {

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -461,7 +461,7 @@ func TestKritisISPLogic(t *testing.T) {
 					getKritisLogs(t))
 			}
 			imgAttestations := getAttestations(t, testCase.attestedImages)
-			for _,i := testCase.attestedImages {
+			for _, i := range testCase.attestedImages {
 				if _, ok := imgAttestations[i]; !ok {
 					t.Errorf("expected %s to be attested. Found no attestations", i)
 				}

--- a/pkg/kritis/admission/admission.go
+++ b/pkg/kritis/admission/admission.go
@@ -87,8 +87,7 @@ func handlePod(ar *v1beta1.AdmissionReview, admitResponse *v1beta1.AdmissionRevi
 	if err := json.Unmarshal(ar.Request.Object.Raw, &pod); err != nil {
 		return err
 	}
-	reviewPod(&pod, admitResponse)
-	return nil
+	return reviewPod(&pod, admitResponse)
 }
 
 func deserializeRequest(w http.ResponseWriter, r *http.Request) (v1beta1.AdmissionReview, error) {

--- a/pkg/kritis/admission/admission.go
+++ b/pkg/kritis/admission/admission.go
@@ -87,7 +87,8 @@ func handlePod(ar *v1beta1.AdmissionReview, admitResponse *v1beta1.AdmissionRevi
 	if err := json.Unmarshal(ar.Request.Object.Raw, &pod); err != nil {
 		return err
 	}
-	return reviewPod(&pod, admitResponse)
+	reviewPod(&pod, admitResponse)
+	return nil
 }
 
 func deserializeRequest(w http.ResponseWriter, r *http.Request) (v1beta1.AdmissionReview, error) {

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis.go
@@ -264,5 +264,6 @@ func getPgpAttestationFromOccurrence(occ *containeranalysispb.Occurrence) metada
 	return metadata.PGPAttestation{
 		Signature: pgp.GetSignature(),
 		KeyID:     pgp.GetPgpKeyId(),
+		OccName:   occ.GetName(),
 	}
 }

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis.go
@@ -264,6 +264,6 @@ func getPgpAttestationFromOccurrence(occ *containeranalysispb.Occurrence) metada
 	return metadata.PGPAttestation{
 		Signature: pgp.GetSignature(),
 		KeyID:     pgp.GetPgpKeyId(),
-		OccName:   occ.GetName(),
+		OccID:     occ.GetName(),
 	}
 }

--- a/pkg/kritis/metadata/metadata.go
+++ b/pkg/kritis/metadata/metadata.go
@@ -48,4 +48,5 @@ type Vulnerability struct {
 type PGPAttestation struct {
 	Signature string
 	KeyID     string
+	OccName   string
 }

--- a/pkg/kritis/metadata/metadata.go
+++ b/pkg/kritis/metadata/metadata.go
@@ -43,10 +43,11 @@ type Vulnerability struct {
 	CVE             string
 }
 
-// PGPAttestation represents the Signature and the Singer Key Id from the
+// PGPAttestation represents the Signature and the Signer Key Id from the
 // containeranalysis Occurrence_Attestation instance.
 type PGPAttestation struct {
 	Signature string
 	KeyID     string
-	OccName   string
+	// OccID is the occurrence ID for containeranalysis Occurrence_Attestation instance
+	OccID string
 }


### PR DESCRIPTION
Check if annotation exits.
Delete those annotations, so for next Int Test run, we do not admit those images because they are already attested.
