### PR TITLE
Replace onlyFixesNotAvailable bool with maximumFixUnavailableSeverity enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ spec:
   - gcr.io/my-project/whitelist-image@sha256:<DIGEST>
   packageVulnerabilityPolicy:
     maximumSeverity: MEDIUM
-    onlyFixesNotAvailable: YES
     whitelistCVEs:
       providers/goog-vulnz/notes/CVE-2017-1000082
       providers/goog-vulnz/notes/CVE-2017-1000082
@@ -76,21 +75,23 @@ Image Security Policy Spec description:
 |-----------|---------------------------|-------------|
 |imageWhitelist | | List of images that are whitelisted and are not inspected by Admission Controller.|
 |packageVulnerabilityPolicy.whitelistCVEs |  | List of CVEs which will be ignored.|
-|packageVulnerabilityPolicy.maximumSeverity| CRITICAL|Defines the tolerance level for vulnerability found in the container image.|
-|packageVulnerabilityPolicy.onlyFixesNotAvailable|  true |when set to "true" only allow packages with vulnerabilities that have fixes out.|
+|packageVulnerabilityPolicy.maximumSeverity| ALLOW_ALL | Tolerance level for vulnerabilities found in the container image.|
+|packageVulnerabilityPolicy.maximumFixUnavailableSeverity |  ALLOW_ALL | The tolerance level for vulnerabilities found that have no fix available.|
 
 Here are the valid values for Policy Specs.
 
 |<td rowspan=1>Field | Value       | Outcome |
 |----------- |-------------|----------- |
-|<td rowspan=5>packageVulnerabilityPolicy.maximumSeverity | LOW | Only allow containers with Low Vulnz. |
-|                          | MEDIUM | Allow Containers with Low and Medium Vulnz. |
-|                                           | HIGH  | Allow Containers with Low, Medium & High Vulnz. |
-|                                           | CRITICAL |  Allow Containers with all Vulnz |
-|                                           | BLOCKALL | Block any Vulnz except listed in whitelist. |
-|<td rowspan=2>packageVulnerabilityPolicy.onlyFixesNotAvailable | true | Only all containers with vulnz not fixed |
-|                                      | false  | All containers with vulnz fixed or not fixed.|
-
+|<td rowspan=5>packageVulnerabilityPolicy.maximumSeverity | LOW | Only allow containers with low vulnerabilities. |
+|                          | MEDIUM | Allow Containers with Low and Medium vulnerabilities. |
+|                                           | HIGH  | Allow Containers with Low, Medium & High vulnerabilities. |
+|                                           | ALLOW_ALL | Allow all vulnerabilities.  |
+|                                           | BLOCK_ALL | Block all vulnerabilities except listed in whitelist. |
+|<td rowspan=5>packageVulnerabilityPolicy.maximumFixUnavailableSeverity | LOW | Only allow containers with low unpatchable vulnerabilities. |
+|                          | MEDIUM | Allow Containers with Low and Medium unpatchable vulnerabilities. |
+|                                           | HIGH  | Allow Containers with Low, Medium & High  unpatchaable vulnerabilities. |
+|                                           | ALLOW_ALL | Allow all unpatchable vulnerabilities.  |
+|                                           | BLOCK_ALL | Block all unpatchable vulnerabilities except listed in whitelist. |
 
 ### AttestationAuthority CRD
 The webhook will attest valid images once they pass the validity check. This is important because re-deployments can occur from scaling events,rescheduling, termination, etc. Attested images are always admitted in custer.

--- a/artifacts/examples/image-security-policy-example.yaml
+++ b/artifacts/examples/image-security-policy-example.yaml
@@ -7,8 +7,8 @@ spec:
   imageWhitelist:
   - gcr.io/my/image
   packageVulnerabilityRequirements:
-    maximumSeverity: HIGH # LOW|MEDIUM|HIGH|CRITICAL|BLOCKALL
-    onlyFixesNotAvailable: true
+    maximumSeverity: HIGH # LOW|MEDIUM|HIGH|CRITICAL|BLOCK_ALL|ALLOW_ALL
+    maximumFixUnavailableSeverity: ALLOW_ALL # LOW|MEDIUM|HIGH|CRITICAL|BLOCK_ALL|ALLOW_ALL
     whitelistCVEs:
       - providers/goog-vulnz/notes/CVE-2017-1000082
       - providers/goog-vulnz/notes/CVE-2017-1000081

--- a/artifacts/integration-examples/image-security-policy-example.yaml
+++ b/artifacts/integration-examples/image-security-policy-example.yaml
@@ -8,7 +8,7 @@ spec:
   - gcr.io/kritis-int-test/nginx-digest-whitelist@sha256:56e0af16f4a9d2401d3f55bc8d214d519f070b5317512c87568603f315a8be72
   packageVulnerabilityRequirements:
     maximumSeverity: HIGH
-    onlyFixesNotAvailable: false
+    maximumFixUnavailableSeverity: ALLOW_ALL
     whitelistCVEs:
       - providers/goog-vulnz/notes/CVE-2017-1000082
       - providers/goog-vulnz/notes/CVE-2017-1000081

--- a/pkg/kritis/admission/admission_test.go
+++ b/pkg/kritis/admission/admission_test.go
@@ -135,7 +135,8 @@ func Test_InvalidISP(t *testing.T) {
 		return &testutil.MockMetadataClient{
 			Vulnz: []metadata.Vulnerability{
 				{
-					Severity: "MEDIUM",
+					Severity:        "MEDIUM",
+					HasFixAvailable: true,
 				},
 			},
 			PGPAttestations: []metadata.PGPAttestation{
@@ -210,6 +211,9 @@ func mockValidPod() func(r *http.Request) (*v1.Pod, v1beta1.AdmissionReview, err
 }
 
 func RunTest(t *testing.T, tc testConfig) {
+	// TODO(tstromberg): Refactor function so that it isn't a test helper.
+	t.Helper()
+
 	// Create a request to pass to our handler.
 	req, err := http.NewRequest("GET", "/", nil)
 	if err != nil {
@@ -234,8 +238,7 @@ func RunTest(t *testing.T, tc testConfig) {
 	expected := `{"response":{"uid":"","allowed":%t,"status":{"metadata":{},"status":"%s","message":"%s"}}}`
 	expected = fmt.Sprintf(expected, tc.allowed, tc.status, tc.message)
 	if rr.Body.String() != expected {
-		t.Errorf("handler returned unexpected body: got %v want %v",
-			rr.Body.String(), expected)
+		t.Errorf("unexpected response: got:\n%v\nwant:\n%v", rr.Body.String(), expected)
 	}
 }
 

--- a/pkg/kritis/apis/kritis/v1beta1/types.go
+++ b/pkg/kritis/apis/kritis/v1beta1/types.go
@@ -34,9 +34,11 @@ type ImageSecurityPolicy struct {
 
 // PackageVulnerabilityRequirements is the requirements for package vulnz for an ImageSecurityPolicy
 type PackageVulnerabilityRequirements struct {
-	MaximumSeverity       string   `json:"maximumSeverity"`
-	OnlyFixesNotAvailable bool     `json:"onlyFixesNotAvailable"`
-	WhitelistCVEs         []string `json:"whitelistCVEs"`
+	// CVE's with fixes.
+	MaximumSeverity string `json:"maximumSeverity"`
+	// CVE's without fixes.
+	MaximumFixUnavailableSeverity string   `json:"maximumFixNotAvailableSeverity"`
+	WhitelistCVEs                 []string `json:"whitelistCVEs"`
 }
 
 // ImageSecurityPolicy is the spec for a ImageSecurityPolicy resource

--- a/pkg/kritis/constants/constants.go
+++ b/pkg/kritis/constants/constants.go
@@ -17,8 +17,10 @@ limitations under the License.
 package constants
 
 const (
-	// Used for blocking all images with CVEs, except for whitelisted CVEs
-	BLOCKALL = "BLOCKALL"
+	// AllowAll is the value used to allow all images with CVEs, except for whitelisted CVEs
+	AllowAll = "ALLOW_ALL"
+	// BlockAll is the value used to block all images with CVEs, except for whitelisted CVEs
+	BlockAll = "BLOCK_ALL"
 
 	// InvalidImageSecPolicy is the key for labels and annotations
 	InvalidImageSecPolicy           = "kritis.grafeas.io/invalidImageSecPolicy"

--- a/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
@@ -109,12 +109,12 @@ func Test_SeverityThresholds(t *testing.T) {
 		{"high", "HIGH", "", []string{"c"}},
 		{"medium", "MEDIUM", "", []string{"h", "c"}},
 		{"low", "LOW", "", []string{"m", "h", "c"}},
-		{"BLOCK_ALL", "BLOCK_ALL", "", []string{"l", "m", "h", "c"}},
-		{"BLOCK_ALL + explicit allow unfixable", "BLOCK_ALL", "ALLOW_ALL", []string{"l", "m", "h", "c"}},
+		{"block all", "BLOCK_ALL", "", []string{"l", "m", "h", "c"}},
+		{"block all fixable, but allow all unfixable", "BLOCK_ALL", "ALLOW_ALL", []string{"l", "m", "h", "c"}},
 		{"explicit allow all", "ALLOW_ALL", "", []string{}},
 		{"allow all but unfixable", "ALLOW_ALL", "BLOCK_ALL", []string{"l_nofix", "m_nofix", "h_nofix", "c_nofix"}},
-		{"medium + high unfixable", "MEDIUM", "HIGH", []string{"h", "c", "c_nofix"}},
-		{"high + medium unfixable", "HIGH", "MEDIUM", []string{"c", "c_nofix", "h_nofix"}},
+		{"medium fixable + high unfixable", "MEDIUM", "HIGH", []string{"h", "c", "c_nofix"}},
+		{"high fixable + medium unfixable", "HIGH", "MEDIUM", []string{"c", "c_nofix", "h_nofix"}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package securitypolicy
 
 import (
+	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
@@ -45,7 +47,7 @@ func Test_ValidISP(t *testing.T) {
 				},
 			}
 			mc := &testutil.MockMetadataClient{
-				Vulnz: []metadata.Vulnerability{{CVE: "m", Severity: test.cveSeverity}},
+				Vulnz: []metadata.Vulnerability{{CVE: "m", Severity: test.cveSeverity, HasFixAvailable: true}},
 			}
 			violations, err := ValidateImageSecurityPolicy(isp, testutil.QualifiedImage, mc)
 			if test.expectErr {
@@ -77,84 +79,68 @@ func Test_UnqualifiedImage(t *testing.T) {
 		{
 			Vulnerability: metadata.Vulnerability{},
 			Violation:     UnqualifiedImageViolation,
-			Reason:        UnqualifiedImageViolationReason(""),
+			Reason:        UnqualifiedImageReason(""),
 		},
 	}
 	testutil.CheckErrorAndDeepEqual(t, false, err, violations, expected)
 }
 
-func Test_BlockallPass(t *testing.T) {
-	isp := v1beta1.ImageSecurityPolicy{
-		Spec: v1beta1.ImageSecurityPolicySpec{
-			PackageVulnerabilityRequirements: v1beta1.PackageVulnerabilityRequirements{
-				MaximumSeverity: "BLOCKALL",
-				WhitelistCVEs:   []string{"l", "m", "c"},
-			},
-		},
-	}
+func Test_SeverityThresholds(t *testing.T) {
 	mc := &testutil.MockMetadataClient{
 		Vulnz: []metadata.Vulnerability{
-			{CVE: "l", Severity: "LOW"},
-			{CVE: "m", Severity: "MEDIUM"},
-			{CVE: "c", Severity: "CRITICAL"},
+			{CVE: "l", Severity: "LOW", HasFixAvailable: true},
+			{CVE: "l_nofix", Severity: "LOW", HasFixAvailable: false},
+			{CVE: "m", Severity: "MEDIUM", HasFixAvailable: true},
+			{CVE: "m_nofix", Severity: "MEDIUM", HasFixAvailable: false},
+			{CVE: "h", Severity: "HIGH", HasFixAvailable: true},
+			{CVE: "h_nofix", Severity: "HIGH", HasFixAvailable: false},
+			{CVE: "c", Severity: "CRITICAL", HasFixAvailable: true},
+			{CVE: "c_nofix", Severity: "CRITICAL", HasFixAvailable: false},
 		},
 	}
-	violations, err := ValidateImageSecurityPolicy(isp, testutil.QualifiedImage, mc)
-	if err != nil {
-		t.Errorf("error validating isp: %v", err)
+	var tests = []struct {
+		name                      string
+		maxSeverity               string
+		maxFixUnavailableSeverity string
+		want                      []string
+	}{
+		{"default to allow all", "", "", []string{}},
+		{"critical", "CRITICAL", "", []string{}}, // same as allow all.
+		{"high", "HIGH", "", []string{"c"}},
+		{"medium", "MEDIUM", "", []string{"h", "c"}},
+		{"low", "LOW", "", []string{"m", "h", "c"}},
+		{"BLOCK_ALL", "BLOCK_ALL", "", []string{"l", "m", "h", "c"}},
+		{"BLOCK_ALL + explicit allow unfixable", "BLOCK_ALL", "ALLOW_ALL", []string{"l", "m", "h", "c"}},
+		{"explicit allow all", "ALLOW_ALL", "", []string{}},
+		{"allow all but unfixable", "ALLOW_ALL", "BLOCK_ALL", []string{"l_nofix", "m_nofix", "h_nofix", "c_nofix"}},
+		{"medium + high unfixable", "MEDIUM", "HIGH", []string{"h", "c", "c_nofix"}},
+		{"high + medium unfixable", "HIGH", "MEDIUM", []string{"c", "c_nofix", "h_nofix"}},
 	}
-	if violations != nil {
-		t.Errorf("got unexpected violations: %v", violations)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isp := v1beta1.ImageSecurityPolicy{
+				Spec: v1beta1.ImageSecurityPolicySpec{
+					PackageVulnerabilityRequirements: v1beta1.PackageVulnerabilityRequirements{
+						MaximumSeverity:               test.maxSeverity,
+						MaximumFixUnavailableSeverity: test.maxFixUnavailableSeverity,
+					},
+				},
+			}
+			vs, err := ValidateImageSecurityPolicy(isp, testutil.QualifiedImage, mc)
+			if err != nil {
+				t.Errorf("%s: error validating isp: %v", test.name, err)
+			}
+			got := []string{}
+			for _, v := range vs {
+				got = append(got, v.Vulnerability.CVE)
+			}
+			sort.Strings(got)
+			sort.Strings(test.want)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("%s: got %s, want %s", test.name, got, test.want)
+			}
+		})
 	}
-}
-
-func Test_BlockallFail(t *testing.T) {
-	isp := v1beta1.ImageSecurityPolicy{
-		Spec: v1beta1.ImageSecurityPolicySpec{
-			PackageVulnerabilityRequirements: v1beta1.PackageVulnerabilityRequirements{
-				MaximumSeverity: "BLOCKALL",
-				WhitelistCVEs:   []string{"m"},
-			},
-		},
-	}
-	mc := &testutil.MockMetadataClient{
-		Vulnz: []metadata.Vulnerability{{CVE: "l", Severity: "LOW"}},
-	}
-	violations, err := ValidateImageSecurityPolicy(isp, testutil.QualifiedImage, mc)
-	expected := []Violation{
-		{
-			Vulnerability: mc.Vulnz[0],
-			Violation:     ExceedsMaxSeverityViolation,
-			Reason:        ExceedsMaxSeverityViolationReason(testutil.QualifiedImage, mc.Vulnz[0], isp),
-		},
-	}
-	testutil.CheckErrorAndDeepEqual(t, false, err, violations, expected)
-}
-
-func Test_MaxSeverityFail(t *testing.T) {
-	isp := v1beta1.ImageSecurityPolicy{
-		Spec: v1beta1.ImageSecurityPolicySpec{
-			PackageVulnerabilityRequirements: v1beta1.PackageVulnerabilityRequirements{
-				MaximumSeverity: "MEDIUM",
-			},
-		},
-	}
-	mc := &testutil.MockMetadataClient{
-		Vulnz: []metadata.Vulnerability{
-			{CVE: "l", Severity: "LOW"},
-			{CVE: "m", Severity: "MEDIUM"},
-			{CVE: "c", Severity: "CRITICAL"},
-		},
-	}
-	violations, err := ValidateImageSecurityPolicy(isp, testutil.QualifiedImage, mc)
-	expected := []Violation{
-		{
-			Vulnerability: mc.Vulnz[2],
-			Violation:     ExceedsMaxSeverityViolation,
-			Reason:        ExceedsMaxSeverityViolationReason(testutil.QualifiedImage, mc.Vulnz[2], isp),
-		},
-	}
-	testutil.CheckErrorAndDeepEqual(t, false, err, violations, expected)
 }
 
 func Test_WhitelistedImage(t *testing.T) {
@@ -201,46 +187,13 @@ func Test_WhitelistedCVEAboveSeverityThreshold(t *testing.T) {
 		t.Errorf("got unexpected violations: %v", violations)
 	}
 }
-
-func Test_OnlyFixesNotAvailableFail(t *testing.T) {
-	isp := v1beta1.ImageSecurityPolicy{
-		Spec: v1beta1.ImageSecurityPolicySpec{
-			PackageVulnerabilityRequirements: v1beta1.PackageVulnerabilityRequirements{
-				MaximumSeverity:       "MEDIUM",
-				OnlyFixesNotAvailable: true,
-			},
-		},
-	}
-	mc := &testutil.MockMetadataClient{
-		Vulnz: []metadata.Vulnerability{
-			{CVE: "l", Severity: "LOW", HasFixAvailable: true},
-			{CVE: "lnofix", Severity: "LOW", HasFixAvailable: false},
-			{CVE: "m", Severity: "MEDIUM", HasFixAvailable: true},
-			{CVE: "mnofix", Severity: "MEDIUM", HasFixAvailable: false},
-		},
-	}
-	violations, err := ValidateImageSecurityPolicy(isp, testutil.QualifiedImage, mc)
-	expected := []Violation{
-		{
-			Vulnerability: mc.Vulnz[1],
-			Violation:     FixesNotAvailableViolation,
-			Reason:        FixesNotAvailableViolationReason(testutil.QualifiedImage, mc.Vulnz[1]),
-		},
-		{
-			Vulnerability: mc.Vulnz[3],
-			Violation:     FixesNotAvailableViolation,
-			Reason:        FixesNotAvailableViolationReason(testutil.QualifiedImage, mc.Vulnz[3]),
-		},
-	}
-	testutil.CheckErrorAndDeepEqual(t, false, err, violations, expected)
-}
 func Test_OnlyFixesNotAvailablePassWithWhitelist(t *testing.T) {
 	isp := v1beta1.ImageSecurityPolicy{
 		Spec: v1beta1.ImageSecurityPolicySpec{
 			PackageVulnerabilityRequirements: v1beta1.PackageVulnerabilityRequirements{
-				MaximumSeverity:       "CRITICAL",
-				OnlyFixesNotAvailable: true,
-				WhitelistCVEs:         []string{"c"},
+				MaximumSeverity:               "CRITICAL",
+				MaximumFixUnavailableSeverity: "BLOCK_ALL",
+				WhitelistCVEs:                 []string{"c"},
 			},
 		},
 	}
@@ -253,51 +206,5 @@ func Test_OnlyFixesNotAvailablePassWithWhitelist(t *testing.T) {
 	}
 	if violations != nil {
 		t.Errorf("got unexpected violations: %v", violations)
-	}
-}
-
-func Test_severityWithinThreshold(t *testing.T) {
-	var tests = []struct {
-		name        string
-		maxSeverity string
-		severity    string
-		expected    bool
-	}{
-		{
-			name:        "test severity below max",
-			maxSeverity: "CRITICAL",
-			severity:    "LOW",
-			expected:    true,
-		},
-		{
-			name:        "test severity equal to max",
-			maxSeverity: "LOW",
-			severity:    "LOW",
-			expected:    true,
-		},
-		{
-			name:        "test blockall max severity",
-			maxSeverity: "BLOCKALL",
-			severity:    "LOW",
-			expected:    false,
-		},
-		{
-			name:        "test severity above max",
-			maxSeverity: "LOW",
-			severity:    "MEDIUM",
-			expected:    false,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got, err := severityWithinThreshold(test.maxSeverity, test.severity)
-			if err != nil {
-				t.Errorf("%s: severityWithinThreshold(%s, %s) encountered error: %v", test.maxSeverity, test.severity, test.name, err)
-			}
-			if got != test.expected {
-				t.Errorf("%s: severityWithinThreshold(%s, %s) = %v, wanted %v", test.name, test.maxSeverity, test.severity, got, test.expected)
-			}
-		})
 	}
 }

--- a/pkg/kritis/crd/securitypolicy/violation.go
+++ b/pkg/kritis/crd/securitypolicy/violation.go
@@ -30,8 +30,8 @@ type Reason string
 // TODO: Add Attestation checking violations
 const (
 	UnqualifiedImageViolation int = iota
-	FixesNotAvailableViolation
-	ExceedsMaxSeverityViolation
+	FixUnavailableViolation
+	SeverityViolation
 )
 
 // Violation represents a vulnerability that violates an ISP
@@ -41,23 +41,29 @@ type Violation struct {
 	Reason        Reason
 }
 
-// UnqualifiedImageViolationReason returns a detailed reason if the image is unqualified
-func UnqualifiedImageViolationReason(image string) Reason {
+// UnqualifiedImageReason returns a detailed reason if the image is unqualified
+func UnqualifiedImageReason(image string) Reason {
 	return Reason(fmt.Sprintf("%s is not a fully qualified image", image))
 }
 
-// FixesAvailableViolationReason returns a detailed reason if a CVE doesn't have a fix available
-func FixesNotAvailableViolationReason(image string, vulnz metadata.Vulnerability) Reason {
-	return Reason(fmt.Sprintf("found CVE %s in %s which has fixes available", vulnz.CVE, image))
+// FixUnavailabileReason returns a detailed reason if an unfixable CVE exceeds max severity
+func FixUnavailableReason(image string, v metadata.Vulnerability, isp v1beta1.ImageSecurityPolicy) Reason {
+	ms := isp.Spec.PackageVulnerabilityRequirements.MaximumFixUnavailableSeverity
+	if ms == constants.BlockAll {
+		return Reason(fmt.Sprintf("found unfixable CVE %s in %s which isn't whitelisted, violating max severity %s",
+			v.CVE, image, ms))
+	}
+	return Reason(fmt.Sprintf("found unfixable CVE %s in %s, which has severity %s exceeding max severity %s",
+		v.CVE, image, v.Severity, ms))
 }
 
-// ExceedsMaxSeverityViolationReason returns a detailed reason if a CVE exceeds max severity
-func ExceedsMaxSeverityViolationReason(image string, vulnz metadata.Vulnerability, isp v1beta1.ImageSecurityPolicy) Reason {
-	maxSeverity := isp.Spec.PackageVulnerabilityRequirements.MaximumSeverity
-	if maxSeverity == constants.BLOCKALL {
+// SeverityReason returns a detailed reason if a CVE exceeds max severity
+func SeverityReason(image string, v metadata.Vulnerability, isp v1beta1.ImageSecurityPolicy) Reason {
+	ms := isp.Spec.PackageVulnerabilityRequirements.MaximumSeverity
+	if ms == constants.BlockAll {
 		return Reason(fmt.Sprintf("found CVE %s in %s which isn't whitelisted, violating max severity %s",
-			vulnz.CVE, image, maxSeverity))
+			v.CVE, image, ms))
 	}
-	return Reason(fmt.Sprintf("found CVE %s in %s, which has severity %s exceeding max severity %s", vulnz.CVE, image,
-		vulnz.Severity, maxSeverity))
+	return Reason(fmt.Sprintf("found CVE %s in %s, which has severity %s exceeding max severity %s",
+		v.CVE, image, v.Severity, ms))
 }


### PR DESCRIPTION
This allows an operator to specify a higher severity level to block unpatchable CVE's with. This allows them to specify, for example:

- Block deployment if image has a LOW fixable CVE
*AND*
- Block deployment if image has a CRITICAL non-fixable CVE.

As opposed to the current behavior, where they can only specify:

- Block deployment if image has a LOW fixable CVE
*AND*
- Block deployment if image has any non-fixable CVE.

To make the behavior easier to parse, this PR also introduces 'ALLOW_ALL'
as an enum. The default behavior, where non-fixable CVE's are allowed, is preserved.