### PR TITLE
Enable GCR API

### DIFF
--- a/install.md
+++ b/install.md
@@ -33,14 +33,20 @@ Once approved, enable the necessary API's:
 
 Enable the Container Analysis API:
 
-```
+```shell
 gcloud services enable containeranalysis.googleapis.com
 ```
 
 Enable the Kubernetes API:
 
-```
+```shell
 gcloud services enable container.googleapis.com
+```
+
+Enable the Container Registry API:
+
+```shell
+gcloud services enable containerregistry.googleapis.com
 ```
 
 Wait for the above API's to be fully enabled, then enable vulnerability scanning:


### PR DESCRIPTION
While running a tutorial on a newly created project, i saw an error when copying the vulnerable image.
```shell
gcloud container images add-tag \
  gcr.io/kritis-tutorial/java-with-vuln:latest \
  gcr.io/$PROJECT/java-with-vuln:latest
This will tag gcr.io/kritis-tutorial/java-with-vuln:latest with:
gcr.io/tejal-test/java-with-vuln:latest
```

Note: I saw an error, when doing this because Container Registry API was not enabled.  Created an PR to add it. 
```
ERROR: (gcloud.container.images.add-tag) Bad status during token exchange: 403
{"errors":[{"code":"DENIED","message":"Token exchange failed for project 'tejal-test'. Please enable Google Container Registry API in Cloud Console at https://console.cloud.google.com/apis/api/containerregistry.googleapis.com/overview?project=tejal-test before performing this operation."}]}
```