### PR TITLE
Fix lint errors blocking the enablement of the go-lint module

### DIFF
--- a/cmd/kritis/admission/main.go
+++ b/cmd/kritis/admission/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/grafeas/kritis/pkg/kritis/metadata/containeranalysis"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 var (

--- a/cmd/kritis/kubectl/plugins/resolve/cmd/root_test.go
+++ b/cmd/kritis/kubectl/plugins/resolve/cmd/root_test.go
@@ -63,10 +63,8 @@ func Test_RootCmd(t *testing.T) {
 }
 
 func Test_resolveFilepaths(t *testing.T) {
-	originalKPLFF := os.Getenv(KUBECTL_PLUGINS_LOCAL_FLAG_FILENAME)
-	originalPWD := os.Getenv(PWD)
-	defer os.Setenv(KUBECTL_PLUGINS_LOCAL_FLAG_FILENAME, originalKPLFF)
-	defer os.Setenv(PWD, originalPWD)
+	originalKPLFF := os.Getenv(localFlagFilenameEnv)
+	defer os.Setenv(localFlagFilenameEnv, originalKPLFF)
 
 	file, err := ioutil.TempFile("", "")
 	if err != nil {
@@ -76,14 +74,10 @@ func Test_resolveFilepaths(t *testing.T) {
 
 	base := filepath.Base(file.Name())
 	dir := filepath.Dir(file.Name())
-	if err := os.Setenv(KUBECTL_PLUGINS_LOCAL_FLAG_FILENAME, base); err != nil {
+	if err := os.Setenv(localFlagFilenameEnv, base); err != nil {
 		t.Error(err)
 	}
-	if err := os.Setenv(PWD, dir); err != nil {
-		t.Error(err)
-	}
-
 	expected := append(multiArg{}, file.Name())
-	err = resolveFilepaths()
+	err = resolveFilepaths(dir)
 	testutil.CheckErrorAndDeepEqual(t, false, err, expected, files)
 }

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -22,16 +22,16 @@ if ! [ -x "$(command -v golangci-lint)" ]; then
 	${DIR}/install_golint.sh -b $GOPATH/bin v1.9.3
 fi
 
-# TODO(tstromberg): enable golint, deadcode, megacheck once code base is ready.
+# TODO(tstromberg): enable deadcode, megacheck once code base is ready.
 golangci-lint run \
 	--no-config \
 	-E goconst \
 	-E gofmt \
 	-E goimports \
+	-E golint \
 	-E interfacer \
 	-E misspell \
 	-E unconvert \
 	-E unparam \
 	-D deadcode \
-	-D golint \
 	-D megacheck

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -22,16 +22,16 @@ if ! [ -x "$(command -v golangci-lint)" ]; then
 	${DIR}/install_golint.sh -b $GOPATH/bin v1.9.3
 fi
 
-# TODO(tstromberg): enable deadcode, megacheck once code base is ready.
+# TODO(tstromberg): enable golint, deadcode, megacheck once code base is ready.
 golangci-lint run \
 	--no-config \
 	-E goconst \
 	-E gofmt \
 	-E goimports \
-	-E golint \
 	-E interfacer \
 	-E misspell \
 	-E unconvert \
 	-E unparam \
 	-D deadcode \
+	-D golint \
 	-D megacheck

--- a/pkg/kritis/pods/pods.go
+++ b/pkg/kritis/pods/pods.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	patch "k8s.io/apimachinery/pkg/util/strategicpatch"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 var (


### PR DESCRIPTION
Also removes usage of UNIX-specific PWD environment variable. Lint
errors addressed are as follows:

cmd/kritis/kubectl/plugins/resolve/cmd/root.go:36:2: don't use ALL_CAPS
in Go names; use CamelCase (golint)
        KUBECTL_PLUGINS_LOCAL_FLAG_FILENAME = "KUBECTL_PLUGINS_LOCAL_FLAG_FILENAME"
        ^
cmd/kritis/kubectl/plugins/resolve/cmd/root.go:37:2: don't use ALL_CAPS
in Go names; use CamelCase (golint)
        KUBECTL_PLUGINS_LOCAL_FLAG_APPLY    = "KUBECTL_PLUGINS_LOCAL_FLAG_APPLY"
        ^
cmd/kritis/kubectl/plugins/resolve/cmd/root.go:38:2: don't use ALL_CAPS
in Go names; use CamelCase (golint)
        KUBECTL_PLUGINS_CALLER              = "KUBECTL_PLUGINS_CALLER"
        ^
pkg/kritis/pods/pods.go:27:2: a blank import should be only in a main or
test package, or have a comment justifying it (golint)
        _ "k8s.io/client-go/plugin/pkg/client/auth"
        ^