### PR TITLE
Add label to facilitate deletion of kritis resources

### DIFF
--- a/helm-hooks/postinstall/main.go
+++ b/helm-hooks/postinstall/main.go
@@ -30,6 +30,7 @@ var (
 	certificate           string
 	webhookName           string
 	deploymentWebhookName string
+	kritisInstallLabel    string
 	serviceName           string
 )
 
@@ -38,10 +39,11 @@ func init() {
 	flag.StringVar(&deploymentWebhookName, "deployment-webhook-name", "", "The name of the deployment validation webhook.")
 	flag.StringVar(&serviceName, "service-name", "", "The name of the service for the webhook.")
 	flag.StringVar(&tlsSecretName, "tls-secret-name", "", "The name of the kritis tls secret.")
-	flag.Parse()
+	flag.StringVar(&kritisInstallLabel, "kritis-install-label", "", "The label to indicate a resource has been created by kritis")
 }
 
 func main() {
+	flag.Parse()
 	logrus.Infof("running postinstall\nversion %s\ncommit: %s",
 		version.Version,
 		version.Commit,

--- a/helm-hooks/postinstall/postinstall.go
+++ b/helm-hooks/postinstall/postinstall.go
@@ -70,6 +70,8 @@ func createValidationWebhook() {
 kind: ValidatingWebhookConfiguration
 metadata:
   name: %s
+  labels:
+    %s: ""
 webhooks:
   - name: kritis-validation-hook.grafeas.io
     rules:
@@ -89,7 +91,7 @@ webhooks:
         name: %s
         namespace: %s`
 
-	webhookSpec = fmt.Sprintf(webhookSpec, webhookName, certificate, serviceName, namespace)
+	webhookSpec = fmt.Sprintf(webhookSpec, webhookName, kritisInstallLabel, certificate, serviceName, namespace)
 	fmt.Println(webhookSpec)
 	webhookCmd := exec.Command("kubectl", "apply", "-f", "-")
 	webhookCmd.Stdin = bytes.NewReader([]byte(webhookSpec))
@@ -101,6 +103,8 @@ func createValidationDeploymentWebhook() {
 kind: ValidatingWebhookConfiguration
 metadata:
   name: %s
+  labels:
+    %s: ""
 webhooks:
   - name: kritis-validation-hook-deployments.grafeas.io
     rules:
@@ -119,7 +123,7 @@ webhooks:
       service:
         name: %s
         namespace: %s`
-	webhookSpec = fmt.Sprintf(webhookSpec, deploymentWebhookName, certificate, serviceName, namespace)
+	webhookSpec = fmt.Sprintf(webhookSpec, deploymentWebhookName, kritisInstallLabel, certificate, serviceName, namespace)
 	fmt.Println(webhookSpec)
 	webhookCmd := exec.Command("kubectl", "apply", "-f", "-")
 	webhookCmd.Stdin = bytes.NewReader([]byte(webhookSpec))

--- a/helm-hooks/predelete/main.go
+++ b/helm-hooks/predelete/main.go
@@ -39,11 +39,11 @@ func init() {
 	flag.StringVar(&csrName, "csr-name", "", "The name of the kritis csr.")
 	flag.BoolVar(&deleteCsr, "delete-csr", true, "Delete kritis csr")
 	flag.BoolVar(&deleteCRD, "delete-crd", true, "Delete kritis CRDs")
-	flag.Parse()
 }
 
 // The kritis predelete hook is responsible for deleting the webhook, TLS secret and CSR
 func main() {
+	flag.Parse()
 	deleteWebhooks()
 	deleteTLSSecret()
 	if deleteCsr {

--- a/helm-hooks/preinstall/crd.go
+++ b/helm-hooks/preinstall/crd.go
@@ -21,6 +21,8 @@ const (
 kind: CustomResourceDefinition
 metadata:
     name: attestationauthorities.kritis.grafeas.io
+    labels:
+        %s: ""
 spec:
     group: kritis.grafeas.io
     version: v1beta1
@@ -34,6 +36,8 @@ spec:
 kind: CustomResourceDefinition
 metadata:
     name: imagesecuritypolicies.kritis.grafeas.io
+    labels:
+        %s: ""
 spec:
     group: kritis.grafeas.io
     version: v1beta1

--- a/helm-hooks/preinstall/main.go
+++ b/helm-hooks/preinstall/main.go
@@ -31,6 +31,7 @@ var (
 	createNewCSR           bool
 	serviceName            string
 	serviceNameDeployments string
+	kritisInstallLabel     string
 )
 
 func init() {
@@ -39,10 +40,11 @@ func init() {
 	flag.BoolVar(&createNewCSR, "create-new-csr", true, "Set to false in order to only create a new CSR if one is not present.")
 	flag.StringVar(&serviceName, "kritis-service-name", "", "The name of the kritis service for pods.")
 	flag.StringVar(&serviceNameDeployments, "kritis-service-name-deployments", "", "The name of the kritis service for deployments.")
-	flag.Parse()
+	flag.StringVar(&kritisInstallLabel, "kritis-install-label", "", "The label to indicate a resource has been created by kritis")
 }
 
 func main() {
+	flag.Parse()
 	logrus.Infof("running preinstall\nversion %s\ncommit: %s",
 		version.Version,
 		version.Commit,
@@ -59,6 +61,6 @@ func main() {
 	}
 	// Create the TLS secret
 	createTLSSecret()
+	labelTLSSecret()
 	installCRDs()
-
 }

--- a/install.md
+++ b/install.md
@@ -240,10 +240,10 @@ kubectl logs kritis-predelete
 
 Most resources created by kritis will be deleted from your cluster once this Pod has reached `Completed` status.
 
-To delete the remaining resources (which includes the completed preinstall, postinstall and predelete pods, along with a service account) run:
+To delete the remaining resources run:
 
 ```
-kubectl delete pods,serviceaccount --selector kritis.grafeas.io/install --namespace <your namespace>
+kubectl delete pods,serviceaccount,clusterrolebinding --selector kritis.grafeas.io/install --namespace <your namespace>
 ```
 
 NOTE: This will not delete the container analysis secret created above.

--- a/install.md
+++ b/install.md
@@ -238,9 +238,15 @@ And the logs using:
 kubectl logs kritis-predelete
 ```
 
-Kritis will be deleted from your cluster once this Pod has reached `Completed` status.
+Most resources created by kritis will be deleted from your cluster once this Pod has reached `Completed` status.
 
-NOTE: This will not delete the `ServiceAccount` or `ClusterRoleBinding` created during preinstall, or the container analysis secret created above.
+To delete the remaining resources (which includes the completed preinstall, postinstall and predelete pods, along with a service account) run:
+
+```
+kubectl delete pods,serviceaccount --selector kritis.grafeas.io/install --namespace <your namespace>
+```
+
+NOTE: This will not delete the container analysis secret created above.
 
 ## Troubleshooting
 
@@ -261,14 +267,16 @@ kubectl get pods
 
 ### Deleting Kritis Manually
 
-If you're unable to delete kritis via `helm delete <DEPLOYMENT NAME>`, you can manually delete kritis `validatingwebhookconfiguration` with the following commands:
+If you're unable to delete kritis via `helm delete <DEPLOYMENT NAME>`, you can manually delete all kritis resources with the following commands:
 
 ```shell
-kubectl delete validatingwebhookconfiguration kritis-validation-hook \
-  --namespace <YOUR NAMESPACE>
-
-kubectl delete validatingwebhookconfiguration kritis-validation-hook-deployments \
-  --namespace <YOUR NAMESPACE>
+kubectl delete all,validatingwebhookconfiguration,serviceaccount,secret,csr,crd \
+  --selector kritis.grafeas.io/install \
+  --namespace <your namespace>
 ```
 
-`helm delete` should work at this point.
+You should then be able to delete the helm deployment with 
+
+```shell
+helm delete [deployment name] --no-hooks
+```

--- a/kritis-charts/templates/kritis-server-deployment.yaml
+++ b/kritis-charts/templates/kritis-server-deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     chart: {{ template "kritis.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{ .Values.kritisInstallLabel }}: ""
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/kritis-charts/templates/kritis-server-service.yaml
+++ b/kritis-charts/templates/kritis-server-service.yaml
@@ -8,6 +8,7 @@ metadata:
     chart: {{ template "kritis.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{ .Values.kritisInstallLabel }}: ""
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/kritis-charts/templates/postinstall/pod.yaml
+++ b/kritis-charts/templates/postinstall/pod.yaml
@@ -8,6 +8,8 @@ metadata:
     "helm.sh/hook-delete-policy": "hook-succeeded"
     "helm.sh/hook-delete-policy": "hook-failed"
     "helm.sh/hook-delete-policy": "before-hook-creation"
+  labels:
+    {{ .Values.kritisInstallLabel }}: ""
 spec:
   restartPolicy: Never
   containers:
@@ -23,4 +25,6 @@ spec:
       - {{ .Values.tlsSecretName }}
       - "--deployment-webhook-name"
       - {{ .Values.serviceNameDeployments }}
+      - "--kritis-install-label"
+      - {{ .Values.kritisInstallLabel }}
     command: {{ .Values.postinstall.pod.command }}

--- a/kritis-charts/templates/predelete/pod.yaml
+++ b/kritis-charts/templates/predelete/pod.yaml
@@ -9,6 +9,8 @@ metadata:
     "helm.sh/hook-delete-policy": "hook-failed"
     "helm.sh/hook-delete-policy": "before-hook-creation"
     "kritis.grafeas.io/breakglass": "true"
+  labels:
+    {{ .Values.kritisInstallLabel }}: ""
 spec:
   serviceAccountName: {{ .Values.preinstall.serviceAccount }}
   restartPolicy: Never

--- a/kritis-charts/templates/preinstall/clusterrolebinding.yaml
+++ b/kritis-charts/templates/preinstall/clusterrolebinding.yaml
@@ -8,6 +8,8 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded
     "helm.sh/hook-delete-policy": hook-failed
     "helm.sh/hook-delete-policy": before-hook-creation
+  labels:
+    {{ .Values.kritisInstallLabel }}: ""
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/kritis-charts/templates/preinstall/pod.yaml
+++ b/kritis-charts/templates/preinstall/pod.yaml
@@ -6,9 +6,11 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "3"
-    "helm.sh/hook-delete-policy": hook-succeeded
-    "helm.sh/hook-delete-policy": hook-failed
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-delete-policy": "hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+  labels:
+    {{ .Values.kritisInstallLabel }}: ""
 spec:
   restartPolicy: Never
   serviceAccountName: {{ .Values.preinstall.serviceAccount }}
@@ -26,4 +28,6 @@ spec:
       - {{ .Values.serviceName }}
       - "--kritis-service-name-deployments"
       - {{ .Values.serviceNameDeployments }}
+      - "--kritis-install-label"
+      - {{ .Values.kritisInstallLabel }}
     command: {{ .Values.preinstall.pod.command }}

--- a/kritis-charts/templates/preinstall/serviceaccount.yaml
+++ b/kritis-charts/templates/preinstall/serviceaccount.yaml
@@ -9,3 +9,5 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded
     "helm.sh/hook-delete-policy": hook-failed
     "helm.sh/hook-delete-policy": before-hook-creation
+  labels:
+    {{ .Values.kritisInstallLabel }}: ""

--- a/kritis-charts/templates/rbac.yaml
+++ b/kritis-charts/templates/rbac.yaml
@@ -7,6 +7,8 @@ items:
   kind: ClusterRoleBinding
   metadata:
     name: {{ .Values.clusterRoleBindingName }}
+    labels:
+      {{ .Values.kritisInstallLabel }}: ""
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
@@ -25,6 +27,7 @@ items:
     labels:
       # Add these permissions to the "edit" default role, so that "edit" can see our CRD.
       rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    {{ .Values.kritisInstallLabel }}: ""
   rules:
   - apiGroups: ["kritis.grafeas.io"]
     resources: ["*"]

--- a/kritis-charts/values.yaml
+++ b/kritis-charts/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 1
 
 image:
-  image: kritis-server
   tag: v0.1.0
+  image: kritis-server
   name: kritis-server
   pullPolicy: Always
 
@@ -41,6 +41,8 @@ csrName: tls-webhook-secret-cert
 clusterRoleBindingName: kritis-clusterrolebinding
 clusterRoleName: kritis-clusterrole
 cronInterval: 1h
+
+kritisInstallLabel: "kritis.grafeas.io/install"
 
 repository: gcr.io/kritis-project/
 


### PR DESCRIPTION
I added a `kritis.grafeas.io/install` label to everything that kritis creates so we can delete all kritis resources with one line.

Should fix #152 