### PR TITLE
 Make it possible to debug when ISP and pod are in different namespaces.

### DIFF
--- a/pkg/kritis/review/review.go
+++ b/pkg/kritis/review/review.go
@@ -60,7 +60,7 @@ var (
 func (r Reviewer) Review(images []string, isps []v1beta1.ImageSecurityPolicy, pod *v1.Pod) error {
 	images = util.RemoveGloballyWhitelistedImages(images)
 	if len(images) == 0 {
-		glog.Info("images are all globally whitelisted, returning successful status", images)
+		glog.Infof("images are all globally whitelisted, returning successful status: %s", images)
 		return nil
 	}
 	for _, isp := range isps {
@@ -86,7 +86,7 @@ func (r Reviewer) Review(images []string, isps []v1beta1.ImageSecurityPolicy, po
 					glog.Errorf("error adding attestations %s", err)
 				}
 			}
-			glog.Infof("Found no violations in %s", image)
+			glog.Infof("Found no violations for %s within ISP %s", image, isp.Name)
 		}
 	}
 	return nil


### PR DESCRIPTION
Previously, when the ISP and the pod were in different namespaces, it was baffling to figure out why the pod was allowed access. 