### PR TITLE
Be less patient waiting for deployments, tune logging output

### DIFF
--- a/pkg/kritis/integration_util/cmd.go
+++ b/pkg/kritis/integration_util/cmd.go
@@ -47,7 +47,7 @@ type Commander struct{}
 
 // RunCmdOut runs an exec.Command and returns the stdout and error.
 func (*Commander) RunCmdOut(cmd *exec.Cmd) ([]byte, error) {
-	logrus.Debugf("Running command: %s", cmd.Args)
+	logrus.Infof("Executing: %s", cmd.Args)
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err

--- a/pkg/kritis/integration_util/cmd.go
+++ b/pkg/kritis/integration_util/cmd.go
@@ -84,6 +84,6 @@ func (*Commander) RunCmdOut(cmd *exec.Cmd) ([]byte, error) {
 
 // RunCmd runs an exec.Command.
 func (*Commander) RunCmd(cmd *exec.Cmd) error {
-	logrus.Debugf("Running command: %s", cmd.Args)
+	logrus.Infof("Executing: %s", cmd.Args)
 	return cmd.Run()
 }

--- a/pkg/kritis/kubernetes/wait.go
+++ b/pkg/kritis/kubernetes/wait.go
@@ -45,7 +45,7 @@ func WaitForPodReady(pods corev1.PodInterface, podName string) error {
 		})
 		if err != nil {
 			// Debugf, as this generates a log message every 500ms until a pod comes online
-			logrus.Debugf("Getting pod %s", err)
+			logrus.Debugf("Unable to get pod state for %q: %v", podName, err)
 			return false, nil
 		}
 		return true, nil
@@ -60,7 +60,7 @@ func WaitForPodReady(pods corev1.PodInterface, podName string) error {
 			IncludeUninitialized: true,
 		})
 		if err != nil {
-			return false, fmt.Errorf("not found: %s", podName)
+			return false, fmt.Errorf("pod not found: %s", podName)
 		}
 		switch pod.Status.Phase {
 		case v1.PodRunning:
@@ -81,7 +81,7 @@ func WaitForPodComplete(pods corev1.PodInterface, podName string) error {
 			IncludeUninitialized: true,
 		})
 		if err != nil {
-			logrus.Infof("Unable to get pod %s: %v", podName, err)
+			logrus.Infof("Unable to get pod state for %q: %v", podName, err)
 			return false, nil
 		}
 		switch pod.Status.Phase {
@@ -158,12 +158,12 @@ func WaitForPodsWithLabelRunning(c kubernetes.Interface, ns string, label labels
 		listOpts := meta_v1.ListOptions{LabelSelector: label.String()}
 		pods, err := c.CoreV1().Pods(ns).List(listOpts)
 		if err != nil {
-			glog.Infof("error getting Pods with label selector %q [%v]\n", label.String(), err)
+			glog.Infof("error getting pods with label selector %q [%v]\n", label.String(), err)
 			return false, nil
 		}
 
 		if lastKnownPodNumber != len(pods.Items) {
-			glog.Infof("Found %d Pods for label selector %s\n", len(pods.Items), label.String())
+			glog.Infof("Found %d pods for label selector %s\n", len(pods.Items), label.String())
 			lastKnownPodNumber = len(pods.Items)
 		}
 

--- a/pkg/kritis/kubernetes/wait.go
+++ b/pkg/kritis/kubernetes/wait.go
@@ -44,7 +44,8 @@ func WaitForPodReady(pods corev1.PodInterface, podName string) error {
 			IncludeUninitialized: true,
 		})
 		if err != nil {
-			logrus.Infof("Getting pod %s", err)
+			// Debugf, as this generates a log message every 500ms until a pod comes online
+			logrus.Debugf("Getting pod %s", err)
 			return false, nil
 		}
 		return true, nil
@@ -54,7 +55,7 @@ func WaitForPodReady(pods corev1.PodInterface, podName string) error {
 	}
 
 	logrus.Infof("Waiting for %s to be ready", podName)
-	return wait.PollImmediate(time.Millisecond*500, time.Minute*10, func() (bool, error) {
+	return wait.PollImmediate(time.Millisecond*500, time.Minute*5, func() (bool, error) {
 		pod, err := pods.Get(podName, meta_v1.GetOptions{
 			IncludeUninitialized: true,
 		})
@@ -75,12 +76,12 @@ func WaitForPodReady(pods corev1.PodInterface, podName string) error {
 
 func WaitForPodComplete(pods corev1.PodInterface, podName string) error {
 	logrus.Infof("Waiting for %s to be ready", podName)
-	return wait.PollImmediate(time.Millisecond*500, time.Minute*10, func() (bool, error) {
+	return wait.PollImmediate(time.Millisecond*500, time.Minute*5, func() (bool, error) {
 		pod, err := pods.Get(podName, meta_v1.GetOptions{
 			IncludeUninitialized: true,
 		})
 		if err != nil {
-			logrus.Infof("Getting pod %s", err)
+			logrus.Infof("Unable to get pod %s: %v", podName, err)
 			return false, nil
 		}
 		switch pod.Status.Phase {


### PR DESCRIPTION
Some tweaks I found useful during my integration testing time.

- Log commands invoked by our integration tests at Info level: they don't come often and are very useful.

- When waiting for pods to come online, fail sooner (5 minutes) so that tests are more likely to fail with useful log messages before the testing timeout is encountered.

- Improve internal consistency among log and error messages, and ensure that they include the pod name.