### PR TITLE
run_tests: Add --delete-webhooks, remove obsoleted --remote flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,11 +128,11 @@ clean:
 	rm -rf $(BUILD_DIR)
 .PHONY: integration
 integration: cross
-	go test -ldflags "$(GO_LDFLAGS)" -v -tags integration $(REPOPATH)/integration -timeout 5m -- --remote=true
+	go test -ldflags "$(GO_LDFLAGS)" -v -tags integration $(REPOPATH)/integration -timeout 5m -- -delete-webhooks=false
 
 .PHONY: integration-local
 integration-local:
-	go test -ldflags "$(GO_LDFLAGS)" -v -tags integration $(REPOPATH)/integration -timeout 5m -remote=false -gac-credentials=$(LOCAL_GAC_CREDENTIALS_PATH)
+	go test -ldflags "$(GO_LDFLAGS)" -v -tags integration $(REPOPATH)/integration -timeout 5m -- -gac-credentials=$(LOCAL_GAC_CREDENTIALS_PATH)
 
 .PHONY: build-push-image
 build-push-image: build-image preinstall-image postinstall-image predelete-image

--- a/Makefile
+++ b/Makefile
@@ -128,11 +128,11 @@ clean:
 	rm -rf $(BUILD_DIR)
 .PHONY: integration
 integration: cross
-	go test -ldflags "$(GO_LDFLAGS)" -v -tags integration $(REPOPATH)/integration -timeout 5m -- -delete-webhooks=false
+	go test -ldflags "$(GO_LDFLAGS)" -v -tags integration $(REPOPATH)/integration -timeout 5m -delete-webhooks=false
 
 .PHONY: integration-local
 integration-local:
-	go test -ldflags "$(GO_LDFLAGS)" -v -tags integration $(REPOPATH)/integration -timeout 5m -- -gac-credentials=$(LOCAL_GAC_CREDENTIALS_PATH)
+	go test -ldflags "$(GO_LDFLAGS)" -v -tags integration $(REPOPATH)/integration -timeout 5m -gac-credentials=$(LOCAL_GAC_CREDENTIALS_PATH)
 
 .PHONY: build-push-image
 build-push-image: build-image preinstall-image postinstall-image predelete-image

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -175,6 +175,7 @@ func installKritis(cs kubernetes.Interface, ns *v1.Namespace) (func(*testing.T),
 		return nil, fmt.Errorf("helm failure: %v\n\nhooks: %s\n\npreinstall: %s\n\npostinstall: %s\n\npods: %s", err,
 			hooks, podLogs(preinstallPod, ns), podLogs(postinstallPod, ns), podSummary)
 	}
+
 	// parsing out Kritis release name from 'helm init' out
 	helmName := strings.Split(string(out[:]), "\n")[0]
 	release := strings.Split(helmName, "   ")[1]

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -46,9 +46,9 @@ const (
 
 var (
 	gkeZone        = flag.String("gke-zone", "us-central1-a", "gke zone")
-	gkeClusterName = flag.String("gke-cluster-name", "UNSET_CLUSTER_NAME", "name of the integration test cluster")
-	gcpProject     = flag.String("gcp-project", "UNSET_GCP_PROJECT", "the gcp project where the integration test cluster lives")
-	gacCredentials = flag.String("gac-credentials", "UNSET_CREDENTIALS_PATH", "path to gac.json credentials for --gcp-project")
+	gkeClusterName = flag.String("gke-cluster-name", "test-cluster-2", "name of the integration test cluster")
+	gcpProject     = flag.String("gcp-project", "kritis-int-test", "the gcp project where the integration test cluster lives")
+	gacCredentials = flag.String("gac-credentials", "/tmp/gac.json", "path to gac.json credentials for --gcp-project")
 	deleteWebHooks = flag.Bool("delete-webhooks", true, "delete Kritis webhooks before running tests")
 	cleanup        = flag.Bool("cleanup", true, "cleanup allocated resources on exit")
 )


### PR DESCRIPTION
Stale webhooks make integration testing painful. This PR updates our integration tests so that old ones are removed and replaced with new ones.

We explicitly override the default for the "integration" test target, so that the current Kokoro behavior is unchanged. For webhook cleanup to work properly there, this would need to be coupled together with a locking mechanism.

