### PR TITLE
Refactor Violation as a interface

### DIFF
--- a/pkg/kritis/crd/securitypolicy/securitypolicy.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy.go
@@ -63,8 +63,8 @@ func ValidateImageSecurityPolicy(isp v1beta1.ImageSecurityPolicy, image string, 
 	// Next, check if image in qualified
 	if !resolve.FullyQualifiedImage(image) {
 		violations = append(violations, Violation{
-			VType: policy.UnqualifiedImageViolation,
-			Msg:   UnqualifiedImageReason(image),
+			vType:  policy.UnqualifiedImageViolation,
+			reason: UnqualifiedImageReason(image),
 		})
 		return violations, nil
 	}
@@ -99,9 +99,9 @@ func ValidateImageSecurityPolicy(isp v1beta1.ImageSecurityPolicy, image string, 
 				continue
 			}
 			violations = append(violations, Violation{
-				Vulnerability: v,
-				VType:         policy.FixUnavailableViolation,
-				Msg:           FixUnavailableReason(image, v, isp),
+				vulnerability: v,
+				vType:         policy.FixUnavailableViolation,
+				reason:        FixUnavailableReason(image, v, isp),
 			})
 			continue
 		}
@@ -113,9 +113,9 @@ func ValidateImageSecurityPolicy(isp v1beta1.ImageSecurityPolicy, image string, 
 			continue
 		}
 		violations = append(violations, Violation{
-			Vulnerability: v,
-			VType:         policy.SeverityViolation,
-			Msg:           SeverityReason(image, v, isp),
+			vulnerability: v,
+			vType:         policy.SeverityViolation,
+			reason:        SeverityReason(image, v, isp),
 		})
 	}
 	return violations, nil

--- a/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
@@ -76,12 +76,12 @@ func Test_UnqualifiedImage(t *testing.T) {
 		},
 	}
 	violations, err := ValidateImageSecurityPolicy(isp, "", &testutil.MockMetadataClient{})
-	testutil.CheckError(t, false, err)
-	if len(violations) != 1 {
-		t.Errorf("expected only 1 violation. Got %d", len(violations))
-	}
-	testutil.CheckErrorAndDeepEqual(t, false, err, violations[0].Type(), policy.UnqualifiedImageViolation)
-	testutil.CheckErrorAndDeepEqual(t, false, err, violations[0].Reason(), UnqualifiedImageReason(""))
+	expected := []policy.Violation{}
+	expected = append(expected, Violation{
+		vType:  policy.UnqualifiedImageViolation,
+		reason: UnqualifiedImageReason(""),
+	})
+	testutil.CheckErrorAndDeepEqual(t, false, err, expected, violations)
 }
 
 func Test_SeverityThresholds(t *testing.T) {

--- a/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
 	"github.com/grafeas/kritis/pkg/kritis/metadata"
+	"github.com/grafeas/kritis/pkg/kritis/policy"
 	"github.com/grafeas/kritis/pkg/kritis/testutil"
 )
 
@@ -75,14 +76,12 @@ func Test_UnqualifiedImage(t *testing.T) {
 		},
 	}
 	violations, err := ValidateImageSecurityPolicy(isp, "", &testutil.MockMetadataClient{})
-	expected := []Violation{
-		{
-			Vulnerability: metadata.Vulnerability{},
-			Violation:     UnqualifiedImageViolation,
-			Reason:        UnqualifiedImageReason(""),
-		},
+	testutil.CheckError(t, false, err)
+	if len(violations) != 1 {
+		t.Errorf("expected only 1 violation. Got %d", len(violations))
 	}
-	testutil.CheckErrorAndDeepEqual(t, false, err, violations, expected)
+	testutil.CheckErrorAndDeepEqual(t, false, err, violations[0].Type(), policy.UnqualifiedImageViolation)
+	testutil.CheckErrorAndDeepEqual(t, false, err, violations[0].Reason(), UnqualifiedImageReason(""))
 }
 
 func Test_SeverityThresholds(t *testing.T) {
@@ -132,7 +131,8 @@ func Test_SeverityThresholds(t *testing.T) {
 			}
 			got := []string{}
 			for _, v := range vs {
-				got = append(got, v.Vulnerability.CVE)
+				vuln := v.Details().(metadata.Vulnerability)
+				got = append(got, vuln.CVE)
 			}
 			sort.Strings(got)
 			sort.Strings(test.want)

--- a/pkg/kritis/crd/securitypolicy/violation.go
+++ b/pkg/kritis/crd/securitypolicy/violation.go
@@ -27,24 +27,32 @@ import (
 
 // Violation represents a vulnerability that violates an ISP
 type Violation struct {
-	Vulnerability metadata.Vulnerability
-	VType         policy.ViolationType
-	Msg           policy.Reason
+	vulnerability metadata.Vulnerability
+	vType         policy.ViolationType
+	reason        policy.Reason
+}
+
+func NewViolation(v metadata.Vulnerability, t policy.ViolationType, r policy.Reason) Violation {
+	return Violation{
+		vulnerability: v,
+		vType:         t,
+		reason:        r,
+	}
 }
 
 // Reason returns the reason
 func (v Violation) Reason() policy.Reason {
-	return v.Msg
+	return v.reason
 }
 
 // Type returns the violation type
 func (v Violation) Type() policy.ViolationType {
-	return v.VType
+	return v.vType
 }
 
 // Details returns the detailed violtation
 func (v Violation) Details() interface{} {
-	return v.Vulnerability
+	return v.vulnerability
 }
 
 // UnqualifiedImageReason returns a detailed reason if the image is unqualified

--- a/pkg/kritis/cron/cron_test.go
+++ b/pkg/kritis/cron/cron_test.go
@@ -73,10 +73,7 @@ type imageViolations struct {
 
 func (iv *imageViolations) violationChecker(isp v1beta1.ImageSecurityPolicy, image string, client metadata.Fetcher) ([]policy.Violation, error) {
 	if ok := iv.imageMap[image]; ok {
-		v := securitypolicy.Violation{
-			Vulnerability: metadata.Vulnerability{
-				Severity: "foo",
-			}}
+		v := securitypolicy.NewViolation(metadata.Vulnerability{Severity: "foo"}, 0, "")
 		vs := []policy.Violation{}
 		vs = append(vs, v)
 		return vs, nil

--- a/pkg/kritis/cron/cron_test.go
+++ b/pkg/kritis/cron/cron_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
 	"github.com/grafeas/kritis/pkg/kritis/crd/securitypolicy"
 	"github.com/grafeas/kritis/pkg/kritis/metadata"
+	"github.com/grafeas/kritis/pkg/kritis/policy"
 	"github.com/grafeas/kritis/pkg/kritis/review"
 	"github.com/grafeas/kritis/pkg/kritis/secrets"
 	"github.com/grafeas/kritis/pkg/kritis/testutil"
@@ -70,15 +71,15 @@ type imageViolations struct {
 	imageMap map[string]bool
 }
 
-func (iv *imageViolations) violationChecker(isp v1beta1.ImageSecurityPolicy, image string, client metadata.Fetcher) ([]securitypolicy.Violation, error) {
+func (iv *imageViolations) violationChecker(isp v1beta1.ImageSecurityPolicy, image string, client metadata.Fetcher) ([]policy.Violation, error) {
 	if ok := iv.imageMap[image]; ok {
-		return []securitypolicy.Violation{
-			{
-				Vulnerability: metadata.Vulnerability{
-					Severity: "foo",
-				},
-			},
-		}, nil
+		v := securitypolicy.Violation{
+			Vulnerability: metadata.Vulnerability{
+				Severity: "foo",
+			}}
+		vs := []policy.Violation{}
+		vs = append(vs, v)
+		return vs, nil
 	}
 	return nil, nil
 }

--- a/pkg/kritis/policy/violation.go
+++ b/pkg/kritis/policy/violation.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+// Reason defines violation reason type
+type Reason string
+
+// ViolationType defines type of the violation
+type ViolationType int
+
+// A list of security policy violations
+// TODO: Add Attestation checking violations
+const (
+	UnqualifiedImageViolation ViolationType = iota
+	FixUnavailableViolation
+	SeverityViolation
+)
+
+// Violation represents a Policy Violation.
+type Violation interface {
+	Type() ViolationType
+	Reason() Reason
+	Details() interface{}
+}

--- a/pkg/kritis/review/review.go
+++ b/pkg/kritis/review/review.go
@@ -25,6 +25,7 @@ import (
 	"github.com/grafeas/kritis/pkg/kritis/crd/authority"
 	"github.com/grafeas/kritis/pkg/kritis/crd/securitypolicy"
 	"github.com/grafeas/kritis/pkg/kritis/metadata"
+	"github.com/grafeas/kritis/pkg/kritis/policy"
 	"github.com/grafeas/kritis/pkg/kritis/secrets"
 	"github.com/grafeas/kritis/pkg/kritis/util"
 	"github.com/grafeas/kritis/pkg/kritis/violation"
@@ -133,11 +134,11 @@ Please see instructions `, image)
 	return false
 }
 
-func (r Reviewer) handleViolations(image string, pod *v1.Pod, violations []securitypolicy.Violation) error {
+func (r Reviewer) handleViolations(image string, pod *v1.Pod, violations []policy.Violation) error {
 	errMsg := fmt.Sprintf("found violations in %s", image)
 	// Check if one of the violations is that the image is not fully qualified
 	for _, v := range violations {
-		if v.Violation == securitypolicy.UnqualifiedImageViolation {
+		if v.Type() == policy.UnqualifiedImageViolation {
 			errMsg = fmt.Sprintf(`%s is not a fully qualified image.
 			  You can run 'kubectl plugin resolve-tags' to qualify all images with a digest.
 			  Instructions for installing the plugin can be found at https://github.com/grafeas/kritis/blob/master/cmd/kritis/kubectl/plugins/resolve`, image)

--- a/pkg/kritis/review/review_test.go
+++ b/pkg/kritis/review/review_test.go
@@ -132,14 +132,9 @@ func TestReview(t *testing.T) {
 				PublicKeyData:        sec.PublicKey,
 			}}}, nil
 	}
-	testValidate := func(isp v1beta1.ImageSecurityPolicy, image string, client metadata.Fetcher) ([]policy.Violation, error) {
+	mockValidate := func(isp v1beta1.ImageSecurityPolicy, image string, client metadata.Fetcher) ([]policy.Violation, error) {
 		if image == vulnImage {
-			v := securitypolicy.Violation{
-				Vulnerability: metadata.Vulnerability{
-					Severity: "foo",
-				},
-				VType: 1,
-			}
+			v := securitypolicy.NewViolation(metadata.Vulnerability{Severity: "foo"}, 1, "")
 			vs := []policy.Violation{}
 			vs = append(vs, v)
 			return vs, nil
@@ -237,7 +232,7 @@ func TestReview(t *testing.T) {
 				PGPAttestations: tc.attestations,
 			}
 			r := New(cMock, &Config{
-				Validate:  testValidate,
+				Validate:  mockValidate,
 				Secret:    sMock,
 				IsWebhook: tc.isWebhook,
 				Strategy:  &th,

--- a/pkg/kritis/review/review_test.go
+++ b/pkg/kritis/review/review_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
 	"github.com/grafeas/kritis/pkg/kritis/crd/securitypolicy"
 	"github.com/grafeas/kritis/pkg/kritis/metadata"
+	"github.com/grafeas/kritis/pkg/kritis/policy"
 	"github.com/grafeas/kritis/pkg/kritis/secrets"
 	"github.com/grafeas/kritis/pkg/kritis/testutil"
 	"github.com/grafeas/kritis/pkg/kritis/util"
@@ -131,16 +132,17 @@ func TestReview(t *testing.T) {
 				PublicKeyData:        sec.PublicKey,
 			}}}, nil
 	}
-	testValidate := func(isp v1beta1.ImageSecurityPolicy, image string, client metadata.Fetcher) ([]securitypolicy.Violation, error) {
+	testValidate := func(isp v1beta1.ImageSecurityPolicy, image string, client metadata.Fetcher) ([]policy.Violation, error) {
 		if image == vulnImage {
-			return []securitypolicy.Violation{
-				{
-					Vulnerability: metadata.Vulnerability{
-						Severity: "foo",
-					},
-					Violation: 1,
+			v := securitypolicy.Violation{
+				Vulnerability: metadata.Vulnerability{
+					Severity: "foo",
 				},
-			}, nil
+				VType: 1,
+			}
+			vs := []policy.Violation{}
+			vs = append(vs, v)
+			return vs, nil
 		}
 		return nil, nil
 	}

--- a/pkg/kritis/testutil/util.go
+++ b/pkg/kritis/testutil/util.go
@@ -34,6 +34,7 @@ func CheckErrorAndDeepEqual(t *testing.T, shouldErr bool, err error, expected, a
 		return
 	}
 	if !reflect.DeepEqual(expected, actual) {
+		// TODO: Print diff instead of full structure http://go/go-test-comments#print-diffs
 		t.Errorf("%T differ.\nExpected\n%+v\nActual\n%+v", expected, expected, actual)
 		return
 	}


### PR DESCRIPTION
This is first step of Refactoring Kritis Policy Engine.

Refactoring Violation as policy.Violation interface. 
This will allow other policies like Build Policy to specify their own Violation structs.
The violation.Strategy can now handle ISP as well as Build Policy Violations (in future).