### PR TITLE
add https:// prefix to image when creating occurrences

### DIFF
--- a/pkg/kritis/metadata/containeranalysis/containeranalysis.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis.go
@@ -163,7 +163,7 @@ func getResourceURL(containerImage string) string {
 }
 
 func getResource(image string) *grafeas.Resource {
-	return &grafeas.Resource{Uri: image}
+	return &grafeas.Resource{Uri: getResourceURL(image)}
 }
 
 func getProjectFromNoteReference(ref string) (string, error) {

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_test.go
@@ -136,3 +136,9 @@ func TestGetProjectFromNoteRef(t *testing.T) {
 		})
 	}
 }
+
+func TestGetResource(t *testing.T) {
+	r := getResource("gcr.io/test/image:sha")
+	e := &grafeas.Resource{Uri: "https://gcr.io/test/image:sha"}
+	testutil.CheckErrorAndDeepEqual(t, false, nil, e, r)
+}


### PR DESCRIPTION
In PR https://github.com/grafeas/kritis/pull/277/files#diff-a4c6acceb6d3cac8b345f5b3dfd0f93aR245
I accidently reverted the change where resource url for an image had a "https://" prefix. 
This is causing the BinAuthz flow to error out as it can't find attestations for an image since the urls don't match for the same resource.