### PR TITLE
Remove Base Encoded PGPSignature For PgpAttestation.

### DIFF
--- a/pkg/kritis/attestation/attestation.go
+++ b/pkg/kritis/attestation/attestation.go
@@ -21,7 +21,6 @@ package attestation
 import (
 	"bytes"
 	"crypto"
-	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -48,18 +47,13 @@ var pgpConfig = packet.Config{
 
 // VerifyMessageAttestation verifies if the image is attested using the PEM
 // encoded public key.
-func VerifyMessageAttestation(pubKey string, attestationHash string, message string) error {
-
-	attestation, err := base64.StdEncoding.DecodeString(attestationHash)
-	if err != nil {
-		return err
-	}
+func VerifyMessageAttestation(pubKey string, attestation string, message string) error {
 
 	keyring, err := openpgp.ReadArmoredKeyRing(strings.NewReader(pubKey))
 	if err != nil {
 		return err
 	}
-	buf := bytes.NewBuffer(attestation)
+	buf := bytes.NewBuffer([]byte(attestation))
 	armorBlock, err := armor.Decode(buf)
 	if err != nil {
 		return errors.Wrap(err, "could not decode armor signature")
@@ -87,9 +81,41 @@ func VerifyMessageAttestation(pubKey string, attestationHash string, message str
 	return nil
 }
 
+// DecryptAttestation verifies if the image is attested using the PEM
+// encoded public key.
+func DecryptAttestation(pubKey string, attestation string) ([]byte, error) {
+
+	keyring, err := openpgp.ReadArmoredKeyRing(strings.NewReader(pubKey))
+	if err != nil {
+		return nil, err
+	}
+	buf := bytes.NewBuffer([]byte(attestation))
+	armorBlock, err := armor.Decode(buf)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not decode armor signature")
+	}
+	md, err := openpgp.ReadMessage(armorBlock.Body, keyring, nil, &pgpConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not read armor signature")
+	}
+
+	// MessageDetails.UnverifiedBody signature is not verified until we read it.
+	// This will call PublicKey.VerifySignature for the keys in the keyring.
+	plaintext, err := ioutil.ReadAll(md.UnverifiedBody)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not verify armor signature")
+	}
+	// Make sure after reading the UnverifiedBody above, there is no signature error.
+	if md.SignatureError != nil || md.Signature == nil {
+		return nil, fmt.Errorf("bad signature found: %s or no signature found for given key", md.SignatureError)
+	}
+
+	return plaintext, nil
+}
+
 // CreateMessageAttestation attests the message using the given public and private key.
 // pubKey: PEM Encoded Public Key
-// privKey: PEM Decoded Private Key
+// privKey: PEM Encoded Private Key
 // message: Message to attest
 func CreateMessageAttestation(pubKey string, privKey string, message string) (string, error) {
 	// Create a PgpKey from Encoded Public Key
@@ -121,7 +147,7 @@ func CreateMessageAttestation(pubKey string, privKey string, message string) (st
 	}
 	w.Close()
 	armorWriter.Close()
-	return base64.StdEncoding.EncodeToString(b.Bytes()), nil
+	return string(b.Bytes()), nil
 }
 
 func createEntityFromKeys(pubKey *packet.PublicKey, privKey *packet.PrivateKey) (*openpgp.Entity, error) {

--- a/pkg/kritis/attestation/attestation_test.go
+++ b/pkg/kritis/attestation/attestation_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package attestation
 
 import (
-	"encoding/base64"
 	"testing"
 
 	"github.com/grafeas/kritis/pkg/kritis/testutil"
@@ -52,7 +51,7 @@ func TestAttestations(t *testing.T) {
 }
 
 func TestGPGArmorSignIntegration(t *testing.T) {
-	if err := VerifyMessageAttestation(testutil.Base64PublicTestKey(t), base64.StdEncoding.EncodeToString([]byte(expectedSig)), "test"); err != nil {
+	if err := VerifyMessageAttestation(testutil.Base64PublicTestKey(t), expectedSig, "test"); err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}
 }

--- a/pkg/kritis/container/container.go
+++ b/pkg/kritis/container/container.go
@@ -29,12 +29,13 @@ import (
 // AtomicContainerSig represents Red Hat’s Atomic Host attestation signature format
 // defined here https://github.com/aweiteka/image/blob/e5a20d98fe698732df2b142846d007b45873627f/docs/signature.md
 type AtomicContainerSig struct {
-	Critical *Critical         `json:"critical"`
+	Critical *critical         `json:"critical"`
 	Optional map[string]string `json:"optional,omitempty"`
 }
 
+// NewAtomicContainerSig creates a AtomicContainerSig from given image and optional map.
 func NewAtomicContainerSig(image string, optional map[string]string) (*AtomicContainerSig, error) {
-	critical, err := NewCritical(image)
+	critical, err := newCritical(image)
 	if err != nil {
 		return nil, err
 	}
@@ -44,41 +45,46 @@ func NewAtomicContainerSig(image string, optional map[string]string) (*AtomicCon
 	}, nil
 }
 
-type Critical struct {
-	Identity *Identity `json:"identity"`
-	Image    *Image    `json:"image"`
+type critical struct {
+	Identity *identity `json:"identity"`
+	Image    *image    `json:"image"`
 	Type     string    `json:"type"`
 }
 
-func NewCritical(image string) (*Critical, error) {
+func newCritical(image string) (*critical, error) {
 	digest, err := name.NewDigest(image, name.StrictValidation)
 	if err != nil {
 		return nil, err
 	}
-	return &Critical{
-		Identity: NewIdentity(digest.Repository.Name()),
-		Image:    NewImage(digest.DigestStr()),
+	return &critical{
+		Identity: newIdentity(digest.Repository.Name()),
+		Image:    newImage(digest.DigestStr()),
 		Type:     constants.AtomicContainerSigType,
 	}, nil
 }
 
-type Identity struct {
+// Equals returns if the Identity and Image fields for the host are same.
+func (c1 *critical) Equals(c2 *critical) bool {
+	return *c1.Identity == *c2.Identity && *c1.Image == *c2.Image
+}
+
+type identity struct {
 	DockerRef string `json:"docker-reference"`
 }
 
-func NewIdentity(image string) *Identity {
-	return &Identity{
+func newIdentity(image string) *identity {
+	return &identity{
 		DockerRef: image,
 	}
 }
 
-type Image struct {
-	DockerDigest string `json:"docker-manifest-digest"`
+type image struct {
+	Digest string `json:"docker-manifest-digest"`
 }
 
-func NewImage(digest string) *Image {
-	return &Image{
-		DockerDigest: digest,
+func newImage(digest string) *image {
+	return &image{
+		Digest: digest,
 	}
 }
 
@@ -98,18 +104,18 @@ func (acs *AtomicContainerSig) CreateAttestationSignature(pgpSigningKey *secrets
 	return attestation.CreateMessageAttestation(pgpSigningKey.PublicKey, pgpSigningKey.PrivateKey, hostStr)
 }
 
-func (acs *AtomicContainerSig) VerifyAttestationSignature(publicKey string, attestationHash string) error {
-	hostSig, err := attestation.DecryptAttestation(publicKey, attestationHash)
+func (acs *AtomicContainerSig) VerifyAttestationSignature(publicKey string, sig string) error {
+	hostSig, err := attestation.GetPlainMessage(publicKey, sig)
 	if err != nil {
 		return err
 	}
-	// Unmarshall the json host string
+	// Unmarshall the json host string to get AtomicContainerSig struct
 	var host AtomicContainerSig
 	if err := json.Unmarshal(hostSig, &host); err != nil {
-		panic(err)
+		return err
 	}
-	//TODO: Add equals logic
-	if *host.Critical.Identity != *acs.Critical.Identity || *host.Critical.Image != *acs.Critical.Image {
+
+	if !host.Critical.Equals(acs.Critical) {
 		h1, _ := host.JSON()
 		h2, _ := acs.JSON()
 		return fmt.Errorf("sig not verified. Expected %s, Got %s", h1, h2)

--- a/pkg/kritis/container/container.go
+++ b/pkg/kritis/container/container.go
@@ -26,6 +26,11 @@ import (
 	"github.com/grafeas/kritis/pkg/kritis/secrets"
 )
 
+// for testing
+var (
+	hType = constants.AtomicContainerSigType
+)
+
 // AtomicContainerSig represents Red Hat’s Atomic Host attestation signature format
 // defined here https://github.com/aweiteka/image/blob/e5a20d98fe698732df2b142846d007b45873627f/docs/signature.md
 type AtomicContainerSig struct {
@@ -45,6 +50,11 @@ func NewAtomicContainerSig(image string, optional map[string]string) (*AtomicCon
 	}, nil
 }
 
+// Equals returns if the Identity and Image fields for the host are same.
+func (c1 *AtomicContainerSig) Equals(c2 *AtomicContainerSig) bool {
+	return c1.Critical.Equals(c2.Critical)
+}
+
 type critical struct {
 	Identity *identity `json:"identity"`
 	Image    *image    `json:"image"`
@@ -59,7 +69,7 @@ func newCritical(image string) (*critical, error) {
 	return &critical{
 		Identity: newIdentity(digest.Repository.Name()),
 		Image:    newImage(digest.DigestStr()),
-		Type:     constants.AtomicContainerSigType,
+		Type:     hType,
 	}, nil
 }
 
@@ -115,7 +125,7 @@ func (acs *AtomicContainerSig) VerifyAttestationSignature(publicKey string, sig 
 		return err
 	}
 
-	if !host.Critical.Equals(acs.Critical) {
+	if !host.Equals(acs) {
 		h1, _ := host.JSON()
 		h2, _ := acs.JSON()
 		return fmt.Errorf("sig not verified. Expected %s, Got %s", h1, h2)

--- a/pkg/kritis/container/container.go
+++ b/pkg/kritis/container/container.go
@@ -51,8 +51,8 @@ func NewAtomicContainerSig(image string, optional map[string]string) (*AtomicCon
 }
 
 // Equals returns if the Identity and Image fields for the host are same.
-func (c1 *AtomicContainerSig) Equals(c2 *AtomicContainerSig) bool {
-	return c1.Critical.Equals(c2.Critical)
+func (acs *AtomicContainerSig) Equals(acsOther *AtomicContainerSig) bool {
+	return acs.Critical.Equals(acsOther.Critical)
 }
 
 type critical struct {

--- a/pkg/kritis/container/container_test.go
+++ b/pkg/kritis/container/container_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package container
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -142,11 +143,21 @@ func TestValidateAttestationSignature(t *testing.T) {
 }
 
 func TestGPGArmorSignVerifyIntegration(t *testing.T) {
+	goodImage = "gcr.io/pso-sec-train-default/mynginx@sha256:958123f8ad595b4ec16757566c1f83aa5e64fe02625e4a7f8cc61254abac28d5"
 	container, err := NewAtomicContainerSig(goodImage, map[string]string{})
+	fmt.Println(container.JSON())
+	secret := &secrets.PGPSigningSecret{
+		PrivateKey: privateKey,
+		PublicKey:  pubKey,
+		SecretName: "demo-testing",
+	}
+	sig, err := container.CreateAttestationSignature(secret)
+	fmt.Println(sig)
+
 	if err != nil {
 		t.Fatalf("Unexpected error %s", err)
 	}
-	if err := container.VerifyAttestationSignature(testutil.Base64PublicTestKey(t), expectedSig); err != nil {
+	if err := container.VerifyAttestationSignature(pubKey, sig); err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}
 }
@@ -154,3 +165,53 @@ func TestGPGArmorSignVerifyIntegration(t *testing.T) {
 // Base64 encoded signarute.
 // Created using gpg --armor --sign -u test@kritis.org <atomic_host_json_representation.txt> | base64
 var expectedSig = "LS0tLS1CRUdJTiBQR1AgTUVTU0FHRS0tLS0tCgpvd0did012TXdNVzRyanR6aW1DeTZHTEcwd2Uwa3hpaWszMU9WaXNsRjJXV1pDWW41aWhaVlN0bHBxVG1sV1NXClZJTFlLZm5KMmFsRnVrV3BhYWxGcVhuSnFVcFdTdW5KUlhxWitmclpJQjNGdWdWRitWbXB5U1V3Ym5GcVVWbHEKa1ZLdGpsSm1ibUo2S3BJUnVZbDVtV21weFNXNktabnBRQXBvVUhGR29wR3BtVldTY1pweGFuSnlXb3FSZWJLbApoWm1Kc2FGUllwcXh1YVdaZ1psNXFubEtrcEdGZ1lGNW9xR3BtVm1xWWFxQmlWR3lxWVdaVVdwcWluRmFtbUdTClViSUZ5TEtTeWdLUTB4Skw4bk16a3hXUzgvTktFalB6VW9zVWlqUFQ4eEpMU290U2xXcHJPeG1Qc0RBd2NqSG8KaVNteVhHcGUrdlhyMXplcjVuMXNQUW9MRGxZbVVGQUl5SlFBWGVjQThZNWVmbEU2QXhlbkFFekppK2ZjL3dNeQpDOFVQOFM5WnZzQjVXdmczNVNYNlMrWFNXdlAxanEvYUovek9Za2VkaHVHUm9BdWVwL25rY3Zaa0JQWHN0RlppCmMzcnNwZDl3NktDN2tHOXY3NTc0WSsxWHN2bVAvTGtjWFNYOXNxRnc3ZG5mRXlkVSt5NHhmdi9sUzkycFMzOFcKdjJPNmZWQTEzWFhCNnFlZE1YS3JGMmpvdXUrZWwzMm5ZTEhsdS9BS3FmUyt2d2NtQ1BleHJqK1JkM1A5Vm9HNApLY21yVkp1ZWxpek9uelhWYVpXT1VzQnBqdVJYejN4Vys0bE5YckZ0WWNTVGpoVlI4cE1NNDNXRStlZVUzWCtYCjZSRzR1ZTNNZlptYmxpZmJUM1JYaUY2YyttSnk1Zy96TkFrZHRoMGZRb0k5RnBWL3NWazgvVVRHQmVZSmYrMlkKSTdOa3BwMzRPdW5CaXFpM2RYYWR5NXdNMWVyYWx1ZThPY0ZhVmhJUlZMS3QyS3B2YzJIRys1MC9lVk5aQ2dKZQo3VkxvVzVZcG0vMVg3ZTZKTUNPRFZRL1dxTXlJWWxsbTV6L3pZNmlVWDVVVzc2eWdxdGRUNWxuZGJCS3QzQ041Cm4ySGRoTjJucXo0K3VoRzdVbStWVkdUMXlRS3puOHV1K0hCZnZhdDNMVkh2MDlFVFF1MUMxNXFtWnZheXVWMWkKMWxMeE9jVDBiLzNYTjIyZjdrNFg4MWI3cmdZQQo9ZU9GVwotLS0tLUVORCBQR1AgTUVTU0FHRS0tLS0tCg=="
+var privateKey = `-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+lQOYBFuQP8IBCAC8YGxLmNjQr3zS1bUxXmYhSiG27BXasTtTdv1L7e9qgyPfXTbl
+bDtmRvZHVAWC62LaESBGpXhiNDAOBxqhKTL4fuY4iI0iARnSR9ut1rezVtqVcSNp
+A02n+S2LO3i+aA01H1iCPKPvYaznhdFUDnqsNGoW0Lx/cO95foSSZhAQdZqXjkgy
+7EIsXclrGpHOLPpAow8eNen671z/0Aa/JOqyKTuML5lxtSk1hZPXdFDo7ICMKpiY
+hwQgFSsmMgVPSuS0Q8l54m4IS3JWkw4t2la37kmufZrWQTTqVdWJKNUFrKhzJI0Z
+kZJ9iK9bfd3pqTpVty0vNG5S3R9lYhoJ4Uw3ABEBAAEAB/wKzaLYUQs6KJ5Jfx0V
+mDrWNOirE24LbTegSUYsiRg+bQftIuznimX7rx0nqQ9p2zL/m5TUyF+XjjOlUk36
+KSE1tB1i553kcdi3wQw9s380h0og4OytdJWLCRTOE9qQXOpI/iO20GB8dYcTfg6r
+ueraHmVpKo5s5p6tQo660KSiNOs40eeRLRPvuj3LuM1e4CMwAJIzH0hrgR83y+G+
+GzznJ3uj6TPSDyQcaD7JladrpCdgp1CZejuADkZaaC6Qio/xcefbFjlnf3aFa/Mz
+ePBXEQgDB0n/Jby7F99ojWkavkGvONB/epW8Yg5b1itb+n1yaGxWYRJCqOhhwrf1
+S3LpBADZv2pUKXZDijkEvGHJHaldBfmWKIYsml6rK2jSI/i2FmffJXZXh+a8P+wD
+9ji+5fDY0xVkzg52qKWOI2dPBLX6GvGrAFh8LbWpJpmvriMmvsR1jcYb5U39JnYu
+UK2S10W/wzLfxyXptcGlkToq2ZnkcZH/95NVa/SqxulAbNruOQQA3XggqFMdTggP
+wQp/Fie1xkqVKUoLczepMy4zz+cnO5AvGpP1/3OzyDn+jy0dH7L655djYMJXysgy
+y5Zazje0udR8kQpFoPSUN89Bsi4bh5C40zRHUC+70RjwVzGdTdFndXFZVDYLz4nX
+8prsrDUW1Tvqr37Yzbluf2dCniaEDe8EALsOXPlpob3myW6v7F6eisVWVELObrds
+AV1jiEnw3kij40xBAPQRiqO2Xcv57wzYdVZFHUant9Tx363cHpNI5HZg5/iGDY91
+1fh+pyp/IN5bg7jicaiqfSrZhGVF1T2gVrMGOdiDTBqy/GCZGd6urNydVTcWmc4U
+1ELtVNegsqd8QSO0LSJEZW1vIEF0dGVzdG9yIiA8ImJyYWRnZWVzYW1hbkBsb25p
+bWJ1cy5jb20iPokBTgQTAQgAOBYhBISe2sQ9HxgEdsaG2pfIcvTkSQo2BQJbkD/C
+AhsvBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheAAAoJEJfIcvTkSQo2qFQH/ibRySV7
+uMZyM6VRbhiwl5ziwkbVhhh2RpAelNez0WSw/c6oU+M6MNxU8O/VEEfq6jnc1iFN
+zP4PEXjjyENrRCILdEN+hzBRx5KD7GqcjwnnX5JtJT9m5ROA3+j7cAA0cN2kgYGl
+TyS+1ePeyvq0j6okTLCIb9hUXdg/nnZsR/a1LiglS/wDbIEfhMqIM46J2xrtonos
+Zg5vvLzJYf44EF7LZ7uC5pwspOznrq+3Dq9CmC4wO5LtnlKmMZikoS0H4XFVbvc1
+mT21Lmtxhep86qZBvhnHNf5+FMXp/t1IXRErItno0EbJ3a9seaFep2Hk9FfpksKe
+8U/4OT7eaOlZvyU=
+=sJcY
+-----END PGP PRIVATE KEY BLOCK-----`
+var pubKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQENBFuQP8IBCAC8YGxLmNjQr3zS1bUxXmYhSiG27BXasTtTdv1L7e9qgyPfXTbl
+bDtmRvZHVAWC62LaESBGpXhiNDAOBxqhKTL4fuY4iI0iARnSR9ut1rezVtqVcSNp
+A02n+S2LO3i+aA01H1iCPKPvYaznhdFUDnqsNGoW0Lx/cO95foSSZhAQdZqXjkgy
+7EIsXclrGpHOLPpAow8eNen671z/0Aa/JOqyKTuML5lxtSk1hZPXdFDo7ICMKpiY
+hwQgFSsmMgVPSuS0Q8l54m4IS3JWkw4t2la37kmufZrWQTTqVdWJKNUFrKhzJI0Z
+kZJ9iK9bfd3pqTpVty0vNG5S3R9lYhoJ4Uw3ABEBAAG0LSJEZW1vIEF0dGVzdG9y
+IiA8ImJyYWRnZWVzYW1hbkBsb25pbWJ1cy5jb20iPokBTgQTAQgAOBYhBISe2sQ9
+HxgEdsaG2pfIcvTkSQo2BQJbkD/CAhsvBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheA
+AAoJEJfIcvTkSQo2qFQH/ibRySV7uMZyM6VRbhiwl5ziwkbVhhh2RpAelNez0WSw
+/c6oU+M6MNxU8O/VEEfq6jnc1iFNzP4PEXjjyENrRCILdEN+hzBRx5KD7Gqcjwnn
+X5JtJT9m5ROA3+j7cAA0cN2kgYGlTyS+1ePeyvq0j6okTLCIb9hUXdg/nnZsR/a1
+LiglS/wDbIEfhMqIM46J2xrtonosZg5vvLzJYf44EF7LZ7uC5pwspOznrq+3Dq9C
+mC4wO5LtnlKmMZikoS0H4XFVbvc1mT21Lmtxhep86qZBvhnHNf5+FMXp/t1IXREr
+Itno0EbJ3a9seaFep2Hk9FfpksKe8U/4OT7eaOlZvyU=
+=r759
+-----END PGP PUBLIC KEY BLOCK-----`

--- a/pkg/kritis/container/container_test.go
+++ b/pkg/kritis/container/container_test.go
@@ -214,7 +214,6 @@ func TestContainerEquals(t *testing.T) {
 	}
 }
 
-// Base64 encoded signarute.
 // Created using gpg --armor --sign -u test@kritis.org <atomic_host_json_representation.txt> | base64
 var expectedSig = `-----BEGIN PGP MESSAGE-----
 

--- a/pkg/kritis/container/container_test.go
+++ b/pkg/kritis/container/container_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package container
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -54,15 +53,15 @@ func Test_ContainerSigCreation(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			image := strings.Join([]string{test.imageName, test.imageDigest}, test.concatString)
-			actual, err := NewAtomicContainerSig(image, nil)
+			i := strings.Join([]string{test.imageName, test.imageDigest}, test.concatString)
+			actual, err := NewAtomicContainerSig(i, nil)
 			expected := AtomicContainerSig{
-				Critical: &Critical{
-					Identity: &Identity{
+				Critical: &critical{
+					Identity: &identity{
 						DockerRef: test.imageName,
 					},
-					Image: &Image{
-						DockerDigest: test.imageDigest,
+					Image: &image{
+						Digest: test.imageDigest,
 					},
 					Type: "atomic container signature",
 				},
@@ -143,75 +142,59 @@ func TestValidateAttestationSignature(t *testing.T) {
 }
 
 func TestGPGArmorSignVerifyIntegration(t *testing.T) {
-	goodImage = "gcr.io/pso-sec-train-default/mynginx@sha256:958123f8ad595b4ec16757566c1f83aa5e64fe02625e4a7f8cc61254abac28d5"
 	container, err := NewAtomicContainerSig(goodImage, map[string]string{})
-	fmt.Println(container.JSON())
-	secret := &secrets.PGPSigningSecret{
-		PrivateKey: privateKey,
-		PublicKey:  pubKey,
-		SecretName: "demo-testing",
-	}
-	sig, err := container.CreateAttestationSignature(secret)
-	fmt.Println(sig)
-
 	if err != nil {
 		t.Fatalf("Unexpected error %s", err)
 	}
-	if err := container.VerifyAttestationSignature(pubKey, sig); err != nil {
+	if err := container.VerifyAttestationSignature(testutil.Base64PublicTestKey(t), expectedSig); err != nil {
 		t.Fatalf("unexpected error %s", err)
+	}
+}
+
+func TestCriticalEquals(t *testing.T) {
+	tcs := []struct {
+		name    string
+		i1      string
+		i2      string
+		isEqual bool
+	}{{"equal", testutil.QualifiedImage, testutil.QualifiedImage, true},
+		{"not equal", testutil.QualifiedImage, testutil.IntTestImage, false},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			o1, err := newCritical(tc.i1)
+			if err != nil {
+				t.Fatalf("unexpected error %s", err)
+			}
+			o2, err := newCritical(tc.i2)
+			if err != nil {
+				t.Fatalf("unexpected error %s", err)
+			}
+			if o2.Equals(o1) != tc.isEqual {
+				t.Errorf("expected objects to be equal : %t Got %t", tc.isEqual, !tc.isEqual)
+			}
+		})
 	}
 }
 
 // Base64 encoded signarute.
 // Created using gpg --armor --sign -u test@kritis.org <atomic_host_json_representation.txt> | base64
-var expectedSig = "LS0tLS1CRUdJTiBQR1AgTUVTU0FHRS0tLS0tCgpvd0did012TXdNVzRyanR6aW1DeTZHTEcwd2Uwa3hpaWszMU9WaXNsRjJXV1pDWW41aWhaVlN0bHBxVG1sV1NXClZJTFlLZm5KMmFsRnVrV3BhYWxGcVhuSnFVcFdTdW5KUlhxWitmclpJQjNGdWdWRitWbXB5U1V3Ym5GcVVWbHEKa1ZLdGpsSm1ibUo2S3BJUnVZbDVtV21weFNXNktabnBRQXBvVUhGR29wR3BtVldTY1pweGFuSnlXb3FSZWJLbApoWm1Kc2FGUllwcXh1YVdaZ1psNXFubEtrcEdGZ1lGNW9xR3BtVm1xWWFxQmlWR3lxWVdaVVdwcWluRmFtbUdTClViSUZ5TEtTeWdLUTB4Skw4bk16a3hXUzgvTktFalB6VW9zVWlqUFQ4eEpMU290U2xXcHJPeG1Qc0RBd2NqSG8KaVNteVhHcGUrdlhyMXplcjVuMXNQUW9MRGxZbVVGQUl5SlFBWGVjQThZNWVmbEU2QXhlbkFFekppK2ZjL3dNeQpDOFVQOFM5WnZzQjVXdmczNVNYNlMrWFNXdlAxanEvYUovek9Za2VkaHVHUm9BdWVwL25rY3Zaa0JQWHN0RlppCmMzcnNwZDl3NktDN2tHOXY3NTc0WSsxWHN2bVAvTGtjWFNYOXNxRnc3ZG5mRXlkVSt5NHhmdi9sUzkycFMzOFcKdjJPNmZWQTEzWFhCNnFlZE1YS3JGMmpvdXUrZWwzMm5ZTEhsdS9BS3FmUyt2d2NtQ1BleHJqK1JkM1A5Vm9HNApLY21yVkp1ZWxpek9uelhWYVpXT1VzQnBqdVJYejN4Vys0bE5YckZ0WWNTVGpoVlI4cE1NNDNXRStlZVUzWCtYCjZSRzR1ZTNNZlptYmxpZmJUM1JYaUY2YyttSnk1Zy96TkFrZHRoMGZRb0k5RnBWL3NWazgvVVRHQmVZSmYrMlkKSTdOa3BwMzRPdW5CaXFpM2RYYWR5NXdNMWVyYWx1ZThPY0ZhVmhJUlZMS3QyS3B2YzJIRys1MC9lVk5aQ2dKZQo3VkxvVzVZcG0vMVg3ZTZKTUNPRFZRL1dxTXlJWWxsbTV6L3pZNmlVWDVVVzc2eWdxdGRUNWxuZGJCS3QzQ041Cm4ySGRoTjJucXo0K3VoRzdVbStWVkdUMXlRS3puOHV1K0hCZnZhdDNMVkh2MDlFVFF1MUMxNXFtWnZheXVWMWkKMWxMeE9jVDBiLzNYTjIyZjdrNFg4MWI3cmdZQQo9ZU9GVwotLS0tLUVORCBQR1AgTUVTU0FHRS0tLS0tCg=="
-var privateKey = `-----BEGIN PGP PRIVATE KEY BLOCK-----
+var expectedSig = `-----BEGIN PGP MESSAGE-----
 
-lQOYBFuQP8IBCAC8YGxLmNjQr3zS1bUxXmYhSiG27BXasTtTdv1L7e9qgyPfXTbl
-bDtmRvZHVAWC62LaESBGpXhiNDAOBxqhKTL4fuY4iI0iARnSR9ut1rezVtqVcSNp
-A02n+S2LO3i+aA01H1iCPKPvYaznhdFUDnqsNGoW0Lx/cO95foSSZhAQdZqXjkgy
-7EIsXclrGpHOLPpAow8eNen671z/0Aa/JOqyKTuML5lxtSk1hZPXdFDo7ICMKpiY
-hwQgFSsmMgVPSuS0Q8l54m4IS3JWkw4t2la37kmufZrWQTTqVdWJKNUFrKhzJI0Z
-kZJ9iK9bfd3pqTpVty0vNG5S3R9lYhoJ4Uw3ABEBAAEAB/wKzaLYUQs6KJ5Jfx0V
-mDrWNOirE24LbTegSUYsiRg+bQftIuznimX7rx0nqQ9p2zL/m5TUyF+XjjOlUk36
-KSE1tB1i553kcdi3wQw9s380h0og4OytdJWLCRTOE9qQXOpI/iO20GB8dYcTfg6r
-ueraHmVpKo5s5p6tQo660KSiNOs40eeRLRPvuj3LuM1e4CMwAJIzH0hrgR83y+G+
-GzznJ3uj6TPSDyQcaD7JladrpCdgp1CZejuADkZaaC6Qio/xcefbFjlnf3aFa/Mz
-ePBXEQgDB0n/Jby7F99ojWkavkGvONB/epW8Yg5b1itb+n1yaGxWYRJCqOhhwrf1
-S3LpBADZv2pUKXZDijkEvGHJHaldBfmWKIYsml6rK2jSI/i2FmffJXZXh+a8P+wD
-9ji+5fDY0xVkzg52qKWOI2dPBLX6GvGrAFh8LbWpJpmvriMmvsR1jcYb5U39JnYu
-UK2S10W/wzLfxyXptcGlkToq2ZnkcZH/95NVa/SqxulAbNruOQQA3XggqFMdTggP
-wQp/Fie1xkqVKUoLczepMy4zz+cnO5AvGpP1/3OzyDn+jy0dH7L655djYMJXysgy
-y5Zazje0udR8kQpFoPSUN89Bsi4bh5C40zRHUC+70RjwVzGdTdFndXFZVDYLz4nX
-8prsrDUW1Tvqr37Yzbluf2dCniaEDe8EALsOXPlpob3myW6v7F6eisVWVELObrds
-AV1jiEnw3kij40xBAPQRiqO2Xcv57wzYdVZFHUant9Tx363cHpNI5HZg5/iGDY91
-1fh+pyp/IN5bg7jicaiqfSrZhGVF1T2gVrMGOdiDTBqy/GCZGd6urNydVTcWmc4U
-1ELtVNegsqd8QSO0LSJEZW1vIEF0dGVzdG9yIiA8ImJyYWRnZWVzYW1hbkBsb25p
-bWJ1cy5jb20iPokBTgQTAQgAOBYhBISe2sQ9HxgEdsaG2pfIcvTkSQo2BQJbkD/C
-AhsvBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheAAAoJEJfIcvTkSQo2qFQH/ibRySV7
-uMZyM6VRbhiwl5ziwkbVhhh2RpAelNez0WSw/c6oU+M6MNxU8O/VEEfq6jnc1iFN
-zP4PEXjjyENrRCILdEN+hzBRx5KD7GqcjwnnX5JtJT9m5ROA3+j7cAA0cN2kgYGl
-TyS+1ePeyvq0j6okTLCIb9hUXdg/nnZsR/a1LiglS/wDbIEfhMqIM46J2xrtonos
-Zg5vvLzJYf44EF7LZ7uC5pwspOznrq+3Dq9CmC4wO5LtnlKmMZikoS0H4XFVbvc1
-mT21Lmtxhep86qZBvhnHNf5+FMXp/t1IXRErItno0EbJ3a9seaFep2Hk9FfpksKe
-8U/4OT7eaOlZvyU=
-=sJcY
------END PGP PRIVATE KEY BLOCK-----`
-var pubKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
-
-mQENBFuQP8IBCAC8YGxLmNjQr3zS1bUxXmYhSiG27BXasTtTdv1L7e9qgyPfXTbl
-bDtmRvZHVAWC62LaESBGpXhiNDAOBxqhKTL4fuY4iI0iARnSR9ut1rezVtqVcSNp
-A02n+S2LO3i+aA01H1iCPKPvYaznhdFUDnqsNGoW0Lx/cO95foSSZhAQdZqXjkgy
-7EIsXclrGpHOLPpAow8eNen671z/0Aa/JOqyKTuML5lxtSk1hZPXdFDo7ICMKpiY
-hwQgFSsmMgVPSuS0Q8l54m4IS3JWkw4t2la37kmufZrWQTTqVdWJKNUFrKhzJI0Z
-kZJ9iK9bfd3pqTpVty0vNG5S3R9lYhoJ4Uw3ABEBAAG0LSJEZW1vIEF0dGVzdG9y
-IiA8ImJyYWRnZWVzYW1hbkBsb25pbWJ1cy5jb20iPokBTgQTAQgAOBYhBISe2sQ9
-HxgEdsaG2pfIcvTkSQo2BQJbkD/CAhsvBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheA
-AAoJEJfIcvTkSQo2qFQH/ibRySV7uMZyM6VRbhiwl5ziwkbVhhh2RpAelNez0WSw
-/c6oU+M6MNxU8O/VEEfq6jnc1iFNzP4PEXjjyENrRCILdEN+hzBRx5KD7Gqcjwnn
-X5JtJT9m5ROA3+j7cAA0cN2kgYGlTyS+1ePeyvq0j6okTLCIb9hUXdg/nnZsR/a1
-LiglS/wDbIEfhMqIM46J2xrtonosZg5vvLzJYf44EF7LZ7uC5pwspOznrq+3Dq9C
-mC4wO5LtnlKmMZikoS0H4XFVbvc1mT21Lmtxhep86qZBvhnHNf5+FMXp/t1IXREr
-Itno0EbJ3a9seaFep2Hk9FfpksKe8U/4OT7eaOlZvyU=
-=r759
------END PGP PUBLIC KEY BLOCK-----`
+owGbwMvMwMW4rjtzimCy6GLG0we0kxiik31OVislF2WWZCYn5ihZVStlpqTmlWSW
+VILYKfnJ2alFukWpaalFqXnJqUpWSunJRXqZ+frZIB3FugVF+VmpySUwbnFqUVlq
+kVKtjlJmbmJ6KpIRuYl5mWmpxSW6KZnpQApoUHFGopGpmVWScZpxanJyWoqRebKl
+hZmJsaFRYpqxuaWZgZl5qnlKkpGFgYF5oqGpmVmqYaqBiVGyqYWZUWpqinFammGS
+UbIFyLKSygKQ0xJL8nMzkxWS8/NKEjPzUosUijPT8xJLSotSlWprOxmPsDAwcjHo
+iSmyXGpe+vXr1zer5n1sPQoLDlYmUFAIyJQAXecA8Y5eflE6AxenAEzJi+fc/wMy
+C8UP8S9ZvsB5Wvg35SX6S+XSWvP1jq/aJ/zOYkedhuGRoAuep/nkcvZkBPXstFZi
+c3rspd9w6KC7kG9v7574Y+1XsvmP/LkcXSX9sqFw7dnfEydU+y4xfv/lS92pS38W
+v2O6fVA13XXB6qedMXKrF2jouu+el32nYLHlu/AKqfS+vwcmCPexrj+Rd3P9VoG4
+KcmrVJuelizOnzXVaZWOUsBpjuRXz3xW+4lNXrFtYcSTjhVR8pMM43WE+eeU3X+X
+6RG4ue3MfZmblifbT3RXiF6c+mJy5g/zNAkdth0fQoI9FpV/sVk8/UTGBeYJf+2Y
+I7Nkpp34OunBiqi3dXady5wM1eralue8OcFaVhIRVLKt2Kpvc2HG+50/eVNZCgJe
+7VLoW5Ypm/1X7e6JMCODVQ/WqMyIYllm5z/zY6iUX5UW76ygqtdT5lndbBKt3CN5
+n2HdhN2nqz4+uhG7Um+VVGT1yQKzn8uu+HBfvat3LVHv09ETQu1C15qmZvayuV1i
+1lLxOcT0b/3XN22f7k4X81b7rgYA
+=eOFW
+-----END PGP MESSAGE-----`

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis.go
@@ -231,6 +231,7 @@ func (c Client) CreateAttestationOccurence(note *grafeas.Note,
 		KeyId: &attestation.PgpSignedAttestation_PgpKeyId{
 			PgpKeyId: pgpSigningKey.SecretName,
 		},
+		ContentType: attestation.PgpSignedAttestation_SIMPLE_SIGNING_JSON,
 	}
 
 	attestationDetails := &grafeas.Occurrence_Attestation{


### PR DESCRIPTION
While Testing the BinAuthz Demo with @bgeesaman, i discovered, other signing service (GCloud beta CLI api) are creating an PgpAttestation Occurrence as armor encoded text.
```
{
  "attestation": {
    "pgpSignedAttestation": {
      "contentType": "SIMPLE_SIGNING_JSON",
      "pgpKeyId": "849EDAC43D1F180476C686DA97C872F4E4490A36",
      "signature": "-----BEGIN PGP MESSAGE-----
\n\nowGbwMvMwME4/UTRlyeeXGaMaxndksTSU/NSixJLUlPiCxIrc/ITU/SyivPzoqdd\nz6zmUlBQSi7KLMlMTsxRslIA8YEimSmpeSWZJZVwEaBYSn5ydmqRblFqWmpRal5y
\nKlBOKT25SC8zX7+gOF+3ODVZt6QoMTNPNyU1LbE0p0Q/tzIvPTOvQglsQK0O1OTc\nxPRULMbmJuZlpqUWl+imZKYDKZDhxRmJRqZmVpamFoZGxmkWiSmmlqZJJqnJhmbm
\npuamZmbJhmkWxomJpqlmJmmpBkZmRqapJonmaRbJyWaGRqYmiUmJyUYWKaao9pdU\nFoBd7p6fn56TqpCck1+aopCUmZdYWpJRpZCcn1cC9EJqkUJxZnpeYklpUSpIey1X\nLVcnYwALAyMHg5WYIkvLvFtHbOUlWMqOtd2ChTQrEyg8ZWSUkooSU9JTU4sTgV5y\nyMnPy8xNKi3WS87PVWLg4hSAKd8ix/7fV/j5PJWlO3Ij9Rdvso6a/Gayp4CcJNP0\nR2/Wsl2tPRJ7rmnNZK+W3Sl37X4r1itv6XqSdXNOz8fTxw6UbauZL/rfbcbP7JYP\naovCPSNXz1TfpGmgtX3Wz0JprkOL+46fNFupeNHHf8qe3yXsog0L968RXZZeIZpX
\n+L3W6fWU1N1TvdVnTbebU/usYKeecsK3vxahAelv1th3vAkUqxCau932pi2jycxd\nyZ9+Lvv8aqVql/9qfttVPJOvT7Ey3K8jVjvjx9vjX5tO2dj97rdtdr4UsmvBGXZf\nziNl5Y0Xvrz+PtsnP8q/L7lDZgLrhkZuUaMvD+U8Vz2YJpvz7XbQpmvP1Q9+ET05
\nf16ISKvdbgA=\n=QPx7
\n-----END PGP MESSAGE-----\n"
    }
  },
  "kind": "ATTESTATION_AUTHORITY",
  "noteName": "projects/pso-sec-train-default/notes/kritis-authority",
  "resourceUrl": "https://gcr.io/pso-sec-train-default/mynginx@sha256:958123f8ad595b4ec16757566c1f83aa5e64fe02625e4a7f8cc61254abac28d5"
}
```
We were creating the same request with base encoded value for `attestation.pgpSignedAttestation.Signature`
In this PR, 
- the attestation.CreateAttestationMessage now returns the armor encoded PGP Message
- Expose a method attestation.GetPlainMessage to verify the signature and return the plain text. 
- The container.AtomicContainerSig.VerifyAttestationSignature now 
   - unmarshalls the plain text in to AtomicContainerSig, 
  - compares only the image fields. Type Field is ignored since they can be created by different signer service and have different types.