### PR TITLE
Set the PGP key fingerprint as the key id for attestations.

### DIFF
--- a/pkg/kritis/admission/admission.go
+++ b/pkg/kritis/admission/admission.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafeas/kritis/pkg/kritis/admission/constants"
 	kritisv1beta1 "github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
 	kritisconstants "github.com/grafeas/kritis/pkg/kritis/constants"
+	"github.com/grafeas/kritis/pkg/kritis/crd/authority"
 	"github.com/grafeas/kritis/pkg/kritis/crd/securitypolicy"
 	"github.com/grafeas/kritis/pkg/kritis/metadata"
 	"github.com/grafeas/kritis/pkg/kritis/metadata/containeranalysis"
@@ -314,6 +315,7 @@ func getReviewer(client metadata.Fetcher) reviewer {
 		Strategy:  defaultViolationStrategy,
 		IsWebhook: true,
 		Secret:    secrets.Fetch,
+		Auths:     authority.Authorities,
 		Validate:  securitypolicy.ValidateImageSecurityPolicy,
 	})
 }

--- a/pkg/kritis/attestation/attestation.go
+++ b/pkg/kritis/attestation/attestation.go
@@ -59,6 +59,15 @@ func VerifyMessageAttestation(pubKey string, sig string, message string) error {
 	return nil
 }
 
+func GetKeyFingerprint(pubKey string) (string, error) {
+	// Create a PgpKey with only the public key
+	pgpKey, err := NewPgpKey("", pubKey)
+	if err != nil {
+		return "", errors.Wrap(err, "creating PGP key")
+	}
+	return fmt.Sprintf("%X", pgpKey.publicKey.Fingerprint), nil
+}
+
 // GetPlainMessage verifies if the image is attested using the PEM
 // encoded public key and returns the plain test in bytes
 func GetPlainMessage(pubKey string, sig string) ([]byte, error) {

--- a/pkg/kritis/attestation/attestation.go
+++ b/pkg/kritis/attestation/attestation.go
@@ -65,7 +65,7 @@ func GetKeyFingerprint(pubKey string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "creating PGP key")
 	}
-	return fmt.Sprintf("%X", pgpKey.publicKey.Fingerprint), nil
+	return pgpKey.Fingerprint(), nil
 }
 
 // GetPlainMessage verifies if the image is attested using the PEM

--- a/pkg/kritis/attestation/attestation_test.go
+++ b/pkg/kritis/attestation/attestation_test.go
@@ -22,6 +22,14 @@ import (
 	"github.com/grafeas/kritis/pkg/kritis/testutil"
 )
 
+func TestGetKeyFingerprint(t *testing.T) {
+	fingerprint, err := GetKeyFingerprint(testutil.Base64PublicTestKey(t))
+	testutil.CheckError(t, false, err)
+	if fingerprint != testutil.PgpKeyFingerprint {
+		t.Errorf("Expected fingerprint: %q, got %q", testutil.PgpKeyFingerprint, fingerprint)
+	}
+}
+
 var tcAttestations = []struct {
 	name      string
 	message   string

--- a/pkg/kritis/attestation/pgpkey.go
+++ b/pkg/kritis/attestation/pgpkey.go
@@ -64,6 +64,10 @@ func (key *PgpKey) PrivateKey() *packet.PrivateKey {
 	return key.privateKey
 }
 
+func (key *PgpKey) Fingerprint() string {
+	return fmt.Sprintf("%X", key.publicKey.Fingerprint)
+}
+
 func parsePublicKey(publicKey string) (*packet.PublicKey, error) {
 	pkt, err := parseKey(publicKey, openpgp.PublicKeyType)
 	if err != nil {

--- a/pkg/kritis/crd/authority/authority.go
+++ b/pkg/kritis/crd/authority/authority.go
@@ -25,6 +25,9 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+type Lister func(namespace string) ([]v1beta1.AttestationAuthority, error)
+type Fetcher func(namespace string, name string) (v1beta1.AttestationAuthority, error)
+
 // Authorities returns all AttestationAuthority in the specified namespaces
 // Pass in an empty string to get all ISPs in all namespaces
 func Authorities(namespace string) ([]v1beta1.AttestationAuthority, error) {

--- a/pkg/kritis/cron/cron.go
+++ b/pkg/kritis/cron/cron.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grafeas/kritis/pkg/kritis/review"
 	"github.com/grafeas/kritis/pkg/kritis/secrets"
 
+	"github.com/grafeas/kritis/pkg/kritis/crd/authority"
 	"github.com/grafeas/kritis/pkg/kritis/crd/securitypolicy"
 	"github.com/grafeas/kritis/pkg/kritis/violation"
 	corev1 "k8s.io/api/core/v1"
@@ -60,6 +61,7 @@ func NewCronConfig(cs *kubernetes.Clientset, client metadata.Fetcher) *Config {
 		Client:    client,
 		ReviewConfig: &review.Config{
 			Secret:    secrets.Fetch,
+			Auths:     authority.Authorities,
 			Strategy:  defaultViolationStrategy,
 			IsWebhook: false,
 			Validate:  securitypolicy.ValidateImageSecurityPolicy,

--- a/pkg/kritis/cron/cron_test.go
+++ b/pkg/kritis/cron/cron_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/grafeas/kritis/pkg/kritis/secrets"
 	"github.com/grafeas/kritis/pkg/kritis/testutil"
 	"github.com/grafeas/kritis/pkg/kritis/violation"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -132,6 +132,9 @@ func TestCheckPods(t *testing.T) {
 			SecretName: name,
 		}, nil
 	}
+	aMock := func(namespace string) ([]v1beta1.AttestationAuthority, error) {
+		return []v1beta1.AttestationAuthority{}, nil
+	}
 	cMock := &testutil.MockMetadataClient{}
 	type args struct {
 		cfg      Config
@@ -200,6 +203,7 @@ func TestCheckPods(t *testing.T) {
 		tt.args.cfg.ReviewConfig = &review.Config{
 			Validate:  tt.args.validate,
 			Secret:    sMock,
+			Auths:     aMock,
 			IsWebhook: false,
 			Strategy:  &th,
 		}

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis.go
@@ -221,6 +221,11 @@ func (c Client) CreateAttestationOccurence(note *grafeas.Note,
 	if !isValidImageOnGCR(containerImage) {
 		return nil, fmt.Errorf("%s is not a valid image hosted in GCR", containerImage)
 	}
+	fingerprint, err := util.GetAttestationKeyFingerprint(pgpSigningKey)
+	if err != nil {
+		return nil, fmt.Errorf("Can't get fingerprint from PGP siging key %s: %v", pgpSigningKey.SecretName, err)
+	}
+
 	// Create Attestation Signature
 	sig, err := util.CreateAttestationSignature(containerImage, pgpSigningKey)
 	if err != nil {
@@ -229,7 +234,7 @@ func (c Client) CreateAttestationOccurence(note *grafeas.Note,
 	pgpSignedAttestation := &attestation.PgpSignedAttestation{
 		Signature: sig,
 		KeyId: &attestation.PgpSignedAttestation_PgpKeyId{
-			PgpKeyId: pgpSigningKey.SecretName,
+			PgpKeyId: fingerprint,
 		},
 		ContentType: attestation.PgpSignedAttestation_SIMPLE_SIGNING_JSON,
 	}

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	kritisv1beta1 "github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
+	"github.com/grafeas/kritis/pkg/kritis/attestation"
 	"github.com/grafeas/kritis/pkg/kritis/secrets"
 	"github.com/grafeas/kritis/pkg/kritis/testutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -86,6 +87,15 @@ func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
 	occ, err := d.CreateAttestationOccurence(note, testutil.IntTestImage, secret)
 	if err != nil {
 		t.Fatalf("Unexpected error while creating Occurence %v", err)
+	}
+	expectedPgpKeyId, err := attestation.GetKeyFingerprint(pub)
+	if err != nil {
+		t.Fatalf("Unexpected error while extracting PGP key id %v", err)
+	}
+
+	pgpKeyId := occ.GetAttestation().GetAttestation().GetPgpSignedAttestation().GetPgpKeyId()
+	if pgpKeyId != expectedPgpKeyId {
+		t.Errorf("Expected PGP key id: %q, got %q", expectedPgpKeyId, pgpKeyId)
 	}
 	defer d.DeleteOccurrence(occ.GetName())
 	occurrences, err := d.Attestations(testutil.IntTestImage)

--- a/pkg/kritis/testutil/constants.go
+++ b/pkg/kritis/testutil/constants.go
@@ -17,8 +17,9 @@ limitations under the License.
 package testutil
 
 const (
-	QualifiedImage = "gcr.io/image/digest@sha256:0000000000000000000000000000000000000000000000000000000000000000"
-	IntTestImage   = "gcr.io/kritis-int-test/test-image@sha256:3e2e946cb834c4538b789312d566eb16f4a27734fc6b140a3b3f85baafce965f"
+	QualifiedImage    = "gcr.io/image/digest@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	IntTestImage      = "gcr.io/kritis-int-test/test-image@sha256:3e2e946cb834c4538b789312d566eb16f4a27734fc6b140a3b3f85baafce965f"
+	PgpKeyFingerprint = "D283A5F5F5F5ECAA9EF185C5AE8B6994116315A3"
 )
 
 // PublicTestKey is base64 encoded sig for image gcr.io/kritis-project/kritis-server@sha256:b3f3eccfd27c9864312af3796067e7db28007a1566e1e042c5862eed3ff1b2c8

--- a/pkg/kritis/util/util.go
+++ b/pkg/kritis/util/util.go
@@ -47,6 +47,10 @@ func CreateAttestationSignature(image string, pgpSigningKey *secrets.PGPSigningS
 	return attestation.CreateMessageAttestation(pgpSigningKey.PublicKey, pgpSigningKey.PrivateKey, hostStr)
 }
 
+func GetAttestationKeyFingerprint(pgpSigningKey *secrets.PGPSigningSecret) (string, error) {
+	return attestation.GetKeyFingerprint(pgpSigningKey.PublicKey)
+}
+
 // GetOrCreateAttestationNote returns a note if exists and creates one if it does not exist.
 func GetOrCreateAttestationNote(c metadata.Fetcher, a *v1beta1.AttestationAuthority) (*grafeas.Note, error) {
 	n, err := c.AttestationNote(a)


### PR DESCRIPTION
Currently the secret name is set.   The attestation spec requires this to be the fingerprint of the PGP key used for signing.