### PR TITLE
Test enhancements + typo

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -427,6 +427,11 @@
   version = "v1.13.0"
 
 [[projects]]
+  name = "gopkg.in/d4l3k/messagediff.v1"
+  packages = ["."]
+  revision = "b9e99b2f9263a86c71c1ca4507f34502448c58a4"
+
+[[projects]]
   name = "gopkg.in/inf.v0"
   packages = ["."]
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
@@ -645,6 +650,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ba2bcb7ae0cfd03e008dc797b1306d6524db931d5f3e6d0d96dcea1462b0c11c"
+  inputs-digest = "e1781657363fcc06c0d6d98a7920521b85e9c28d66ce024452cbba89a3995e94"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -51,3 +51,7 @@ ignored = ["cloud.google.com/go/devtools/*"]
   [[prune.project]]
     name = "k8s.io/code-generator"
     unused-packages = false
+
+[[constraint]]
+  name = "gopkg.in/d4l3k/messagediff.v1"
+  revision = "b9e99b2f9263a86c71c1ca4507f34502448c58a4"

--- a/pkg/kritis/admission/images_test.go
+++ b/pkg/kritis/admission/images_test.go
@@ -71,7 +71,7 @@ func Test_DeploymentImages(t *testing.T) {
 	}
 	expected := []string{"image1", "image2", "image3"}
 	actual := DeploymentImages(deployment)
-	testutil.CheckErrorAndDeepEqual(t, false, nil, expected, actual)
+	testutil.DeepEqual(t, expected, actual)
 }
 
 func Test_ReplicaSetImages(t *testing.T) {
@@ -98,5 +98,5 @@ func Test_ReplicaSetImages(t *testing.T) {
 	}
 	expected := []string{"image1", "image2", "image3"}
 	actual := ReplicaSetImages(rs)
-	testutil.CheckErrorAndDeepEqual(t, false, nil, expected, actual)
+	testutil.DeepEqual(t, expected, actual)
 }

--- a/pkg/kritis/kubectl/plugins/resolve/resolve_test.go
+++ b/pkg/kritis/kubectl/plugins/resolve/resolve_test.go
@@ -88,7 +88,7 @@ func Test_recursiveGetTaggedImages(t *testing.T) {
 			}
 			actual := recursiveGetTaggedImages(m)
 			sort.Strings(actual)
-			testutil.CheckErrorAndDeepEqual(t, false, nil, test.expected, actual)
+			testutil.DeepEqual(t, test.expected, actual)
 		})
 	}
 }
@@ -221,7 +221,7 @@ func Test_recursiveReplaceImage(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual := recursiveReplaceImage(test.yaml, test.replacements)
-			testutil.CheckErrorAndDeepEqual(t, false, nil, test.expected, actual)
+			testutil.DeepEqual(t, test.expected, actual)
 		})
 	}
 }

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_test.go
@@ -113,7 +113,23 @@ func Test_isRegistryGCR(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual := isRegistryGCR(test.registry)
-			testutil.CheckErrorAndDeepEqual(t, false, nil, test.expected, actual)
+			testutil.DeepEqual(t, test.expected, actual)
+		})
+	}
+}
+
+func Test_getProjectFromContainerImage(t *testing.T) {
+	tests := []struct {
+		image   string
+		project string
+	}{
+		{"gcr.io/project/1", "project"},
+		{"gcr.io/project", "project"},
+		{"gcr.io", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.image, func(t *testing.T) {
+			testutil.DeepEqual(t, tc.project, getProjectFromContainerImage(tc.image))
 		})
 	}
 }
@@ -140,5 +156,5 @@ func TestGetProjectFromNoteRef(t *testing.T) {
 func TestGetResource(t *testing.T) {
 	r := getResource("gcr.io/test/image:sha")
 	e := &grafeas.Resource{Uri: "https://gcr.io/test/image:sha"}
-	testutil.CheckErrorAndDeepEqual(t, false, nil, e, r)
+	testutil.DeepEqual(t, e, r)
 }

--- a/pkg/kritis/pods/pods_test.go
+++ b/pkg/kritis/pods/pods_test.go
@@ -87,7 +87,7 @@ func Test_AddPatch(t *testing.T) {
 				t.Error(err)
 			}
 			expected := fmt.Sprintf(`{"metadata":{"annotations":%s,"labels":%s}}`, annotations, labels)
-			testutil.CheckErrorAndDeepEqual(t, false, err, expected, string(patch))
+			testutil.DeepEqual(t, expected, string(patch))
 		})
 	}
 }
@@ -156,7 +156,7 @@ func Test_DeletePatch(t *testing.T) {
 			if test.noChange {
 				expected = "{}"
 			}
-			testutil.CheckErrorAndDeepEqual(t, false, err, expected, string(patch))
+			testutil.DeepEqual(t, expected, string(patch))
 		})
 	}
 }

--- a/pkg/kritis/testutil/util.go
+++ b/pkg/kritis/testutil/util.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafeas/kritis/pkg/kritis/secrets"
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/armor"
+	"gopkg.in/d4l3k/messagediff.v1"
 )
 
 func CheckErrorAndDeepEqual(t *testing.T, shouldErr bool, err error, expected, actual interface{}) {
@@ -33,9 +34,13 @@ func CheckErrorAndDeepEqual(t *testing.T, shouldErr bool, err error, expected, a
 		t.Error(err)
 		return
 	}
+	DeepEqual(t, expected, actual)
+}
+
+func DeepEqual(t *testing.T, expected, actual interface{}) {
 	if !reflect.DeepEqual(expected, actual) {
-		// TODO: Print diff instead of full structure http://go/go-test-comments#print-diffs
-		t.Errorf("%T differ.\nExpected\n%+v\nActual\n%+v", expected, expected, actual)
+		diff, _ := messagediff.PrettyDiff(expected, actual)
+		t.Errorf("%T differ. %s", expected, diff)
 		return
 	}
 }

--- a/pkg/kritis/util/whitelist_test.go
+++ b/pkg/kritis/util/whitelist_test.go
@@ -47,7 +47,7 @@ func Test_RemoveGloballyWhitelistedImages(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual := RemoveGloballyWhitelistedImages(test.images)
-			testutil.CheckErrorAndDeepEqual(t, false, nil, test.expected, actual)
+			testutil.DeepEqual(t, test.expected, actual)
 		})
 	}
 }

--- a/vendor/gopkg.in/d4l3k/messagediff.v1/.coveralls.yml
+++ b/vendor/gopkg.in/d4l3k/messagediff.v1/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: LWIe7rP7M3hBnAxpsMaZhrVBs2DSyhzoQ

--- a/vendor/gopkg.in/d4l3k/messagediff.v1/.gitignore
+++ b/vendor/gopkg.in/d4l3k/messagediff.v1/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/gopkg.in/d4l3k/messagediff.v1/.travis.yml
+++ b/vendor/gopkg.in/d4l3k/messagediff.v1/.travis.yml
@@ -1,0 +1,25 @@
+language: go
+
+os:
+  - linux
+
+go:
+  - 1.9.x
+  - 1.10.x
+  - tip
+
+allow_failures:
+  - go: tip
+
+
+before_install:
+  - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+  - go get github.com/axw/gocov/gocov
+  - go get github.com/modocache/gover
+  - go get github.com/mattn/goveralls
+
+script:
+  - go test -v -coverprofile=example.coverprofile ./example
+  - go test -v -coverprofile=main.coverprofile
+  - $HOME/gopath/bin/gover
+  - $HOME/gopath/bin/goveralls -service=travis-ci -coverprofile=gover.coverprofile

--- a/vendor/gopkg.in/d4l3k/messagediff.v1/CHANGELOG.md
+++ b/vendor/gopkg.in/d4l3k/messagediff.v1/CHANGELOG.md
@@ -1,0 +1,14 @@
+## nightly
+* Added support for ignoring fields.
+
+## v1.1.0
+
+* Added support for recursive data structures.
+* Fixed bug with embedded fixed length arrays in structs.
+* Added `example/` directory.
+* Minor test bug fixes for future go versions.
+* Added change log.
+
+## v1.0.0
+
+Initial tagged release release.

--- a/vendor/gopkg.in/d4l3k/messagediff.v1/LICENSE
+++ b/vendor/gopkg.in/d4l3k/messagediff.v1/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Tristan Rice
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/gopkg.in/d4l3k/messagediff.v1/README.md
+++ b/vendor/gopkg.in/d4l3k/messagediff.v1/README.md
@@ -1,0 +1,90 @@
+# messagediff [![Build Status](https://travis-ci.org/d4l3k/messagediff.svg?branch=master)](https://travis-ci.org/d4l3k/messagediff) [![Coverage Status](https://coveralls.io/repos/github/d4l3k/messagediff/badge.svg?branch=master)](https://coveralls.io/github/d4l3k/messagediff?branch=master) [![GoDoc](https://godoc.org/github.com/d4l3k/messagediff?status.svg)](https://godoc.org/github.com/d4l3k/messagediff)
+
+A library for doing diffs of arbitrary Golang structs.
+
+If the unsafe package is available messagediff will diff unexported fields in
+addition to exported fields. This is primarily used for testing purposes as it
+allows for providing informative error messages.
+
+Optionally, fields in structs can be tagged as `testdiff:"ignore"` to make
+messagediff skip it when doing the comparison.
+
+
+## Example Usage
+In a normal file:
+```go
+package main
+
+import "gopkg.in/d4l3k/messagediff.v1"
+
+type someStruct struct {
+    A, b int
+    C []int
+}
+
+func main() {
+    a := someStruct{1, 2, []int{1}}
+    b := someStruct{1, 3, []int{1, 2}}
+    diff, equal := messagediff.PrettyDiff(a, b)
+    /*
+        diff =
+        `added: .C[1] = 2
+        modified: .b = 3`
+
+        equal = false
+    */
+}
+
+```
+In a test:
+```go
+import "gopkg.in/d4l3k/messagediff.v1"
+
+...
+
+type someStruct struct {
+    A, b int
+    C []int
+}
+
+func TestSomething(t *testing.T) {
+    want := someStruct{1, 2, []int{1}}
+    got := someStruct{1, 3, []int{1, 2}}
+    if diff, equal := messagediff.PrettyDiff(want, got); !equal {
+        t.Errorf("Something() = %#v\n%s", got, diff)
+    }
+}
+```
+To ignore a field in a struct, just annotate it with testdiff:"ignore" like
+this:
+```go
+package main
+
+import "gopkg.in/d4l3k/messagediff.v1"
+
+type someStruct struct {
+    A int
+    B int `testdiff:"ignore"`
+}
+
+func main() {
+    a := someStruct{1, 2}
+    b := someStruct{1, 3}
+    diff, equal := messagediff.PrettyDiff(a, b)
+    /*
+        equal = true
+        diff = ""
+    */
+}
+```
+
+See the `DeepDiff` function for using the diff results programmatically.
+
+## License
+Copyright (c) 2015 [Tristan Rice](https://fn.lc) <rice@fn.lc>
+
+messagediff is licensed under the MIT license. See the LICENSE file for more information.
+
+bypass.go and bypasssafe.go are borrowed from
+[go-spew](https://github.com/davecgh/go-spew) and have a seperate copyright
+notice.

--- a/vendor/gopkg.in/d4l3k/messagediff.v1/bypass.go
+++ b/vendor/gopkg.in/d4l3k/messagediff.v1/bypass.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2015 Dave Collins <dave@davec.name>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+// NOTE: Due to the following build constraints, this file will only be compiled
+// when the code is not running on Google App Engine and "-tags disableunsafe"
+// is not added to the go build command line.
+// +build !appengine,!disableunsafe
+
+package messagediff
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+const (
+	// UnsafeDisabled is a build-time constant which specifies whether or
+	// not access to the unsafe package is available.
+	UnsafeDisabled = false
+
+	// ptrSize is the size of a pointer on the current arch.
+	ptrSize = unsafe.Sizeof((*byte)(nil))
+)
+
+var (
+	// offsetPtr, offsetScalar, and offsetFlag are the offsets for the
+	// internal reflect.Value fields.  These values are valid before golang
+	// commit ecccf07e7f9d which changed the format.  The are also valid
+	// after commit 82f48826c6c7 which changed the format again to mirror
+	// the original format.  Code in the init function updates these offsets
+	// as necessary.
+	offsetPtr    = uintptr(ptrSize)
+	offsetScalar = uintptr(0)
+	offsetFlag   = uintptr(ptrSize * 2)
+
+	// flagKindWidth and flagKindShift indicate various bits that the
+	// reflect package uses internally to track kind information.
+	//
+	// flagRO indicates whether or not the value field of a reflect.Value is
+	// read-only.
+	//
+	// flagIndir indicates whether the value field of a reflect.Value is
+	// the actual data or a pointer to the data.
+	//
+	// These values are valid before golang commit 90a7c3c86944 which
+	// changed their positions.  Code in the init function updates these
+	// flags as necessary.
+	flagKindWidth = uintptr(5)
+	flagKindShift = uintptr(flagKindWidth - 1)
+	flagRO        = uintptr(1 << 0)
+	flagIndir     = uintptr(1 << 1)
+)
+
+func init() {
+	// Older versions of reflect.Value stored small integers directly in the
+	// ptr field (which is named val in the older versions).  Versions
+	// between commits ecccf07e7f9d and 82f48826c6c7 added a new field named
+	// scalar for this purpose which unfortunately came before the flag
+	// field, so the offset of the flag field is different for those
+	// versions.
+	//
+	// This code constructs a new reflect.Value from a known small integer
+	// and checks if the size of the reflect.Value struct indicates it has
+	// the scalar field. When it does, the offsets are updated accordingly.
+	vv := reflect.ValueOf(0xf00)
+	if unsafe.Sizeof(vv) == (ptrSize * 4) {
+		offsetScalar = ptrSize * 2
+		offsetFlag = ptrSize * 3
+	}
+
+	// Commit 90a7c3c86944 changed the flag positions such that the low
+	// order bits are the kind.  This code extracts the kind from the flags
+	// field and ensures it's the correct type.  When it's not, the flag
+	// order has been changed to the newer format, so the flags are updated
+	// accordingly.
+	upf := unsafe.Pointer(uintptr(unsafe.Pointer(&vv)) + offsetFlag)
+	upfv := *(*uintptr)(upf)
+	flagKindMask := uintptr((1<<flagKindWidth - 1) << flagKindShift)
+	if (upfv&flagKindMask)>>flagKindShift != uintptr(reflect.Int) {
+		flagKindShift = 0
+		flagRO = 1 << 5
+		flagIndir = 1 << 6
+
+		// Commit adf9b30e5594 modified the flags to separate the
+		// flagRO flag into two bits which specifies whether or not the
+		// field is embedded.  This causes flagIndir to move over a bit
+		// and means that flagRO is the combination of either of the
+		// original flagRO bit and the new bit.
+		//
+		// This code detects the change by extracting what used to be
+		// the indirect bit to ensure it's set.  When it's not, the flag
+		// order has been changed to the newer format, so the flags are
+		// updated accordingly.
+		if upfv&flagIndir == 0 {
+			flagRO = 3 << 5
+			flagIndir = 1 << 7
+		}
+	}
+}
+
+// unsafeReflectValue converts the passed reflect.Value into a one that bypasses
+// the typical safety restrictions preventing access to unaddressable and
+// unexported data.  It works by digging the raw pointer to the underlying
+// value out of the protected value and generating a new unprotected (unsafe)
+// reflect.Value to it.
+//
+// This allows us to check for implementations of the Stringer and error
+// interfaces to be used for pretty printing ordinarily unaddressable and
+// inaccessible values such as unexported struct fields.
+func unsafeReflectValue(v reflect.Value) (rv reflect.Value) {
+	indirects := 1
+	vt := v.Type()
+	upv := unsafe.Pointer(uintptr(unsafe.Pointer(&v)) + offsetPtr)
+	rvf := *(*uintptr)(unsafe.Pointer(uintptr(unsafe.Pointer(&v)) + offsetFlag))
+	if rvf&flagIndir != 0 {
+		vt = reflect.PtrTo(v.Type())
+		indirects++
+	} else if offsetScalar != 0 {
+		// The value is in the scalar field when it's not one of the
+		// reference types.
+		switch vt.Kind() {
+		case reflect.Uintptr:
+		case reflect.Chan:
+		case reflect.Func:
+		case reflect.Map:
+		case reflect.Ptr:
+		case reflect.UnsafePointer:
+		default:
+			upv = unsafe.Pointer(uintptr(unsafe.Pointer(&v)) +
+				offsetScalar)
+		}
+	}
+
+	pv := reflect.NewAt(vt, upv)
+	rv = pv
+	for i := 0; i < indirects; i++ {
+		rv = rv.Elem()
+	}
+	return rv
+}

--- a/vendor/gopkg.in/d4l3k/messagediff.v1/bypasssafe.go
+++ b/vendor/gopkg.in/d4l3k/messagediff.v1/bypasssafe.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2015 Dave Collins <dave@davec.name>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+// NOTE: Due to the following build constraints, this file will only be compiled
+// when either the code is running on Google App Engine or "-tags disableunsafe"
+// is added to the go build command line.
+// +build appengine disableunsafe
+
+package messagediff
+
+import "reflect"
+
+const (
+	// UnsafeDisabled is a build-time constant which specifies whether or
+	// not access to the unsafe package is available.
+	UnsafeDisabled = true
+)
+
+// unsafeReflectValue typically converts the passed reflect.Value into a one
+// that bypasses the typical safety restrictions preventing access to
+// unaddressable and unexported data.  However, doing this relies on access to
+// the unsafe package.  This is a stub version which simply returns the passed
+// reflect.Value when the unsafe package is not available.
+func unsafeReflectValue(v reflect.Value) reflect.Value {
+	return v
+}

--- a/vendor/gopkg.in/d4l3k/messagediff.v1/messagediff.go
+++ b/vendor/gopkg.in/d4l3k/messagediff.v1/messagediff.go
@@ -1,0 +1,290 @@
+package messagediff
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+	"unsafe"
+)
+
+// PrettyDiff does a deep comparison and returns the nicely formated results.
+// See DeepDiff for more details.
+func PrettyDiff(a, b interface{}, options ...Option) (string, bool) {
+	d, equal := DeepDiff(a, b, options...)
+	var dstr []string
+	for path, added := range d.Added {
+		dstr = append(dstr, fmt.Sprintf("added: %s = %#v\n", path.String(), added))
+	}
+	for path, removed := range d.Removed {
+		dstr = append(dstr, fmt.Sprintf("removed: %s = %#v\n", path.String(), removed))
+	}
+	for path, modified := range d.Modified {
+		dstr = append(dstr, fmt.Sprintf("modified: %s = %#v\n", path.String(), modified))
+	}
+	sort.Strings(dstr)
+	return strings.Join(dstr, ""), equal
+}
+
+// DeepDiff does a deep comparison and returns the results.
+// If the field is time.Time, use Equal to compare
+func DeepDiff(a, b interface{}, options ...Option) (*Diff, bool) {
+	d := newDiff()
+	opts := &opts{}
+	for _, o := range options {
+		o.apply(opts)
+	}
+	return d, d.diff(reflect.ValueOf(a), reflect.ValueOf(b), nil, opts)
+}
+
+func newDiff() *Diff {
+	return &Diff{
+		Added:    make(map[*Path]interface{}),
+		Removed:  make(map[*Path]interface{}),
+		Modified: make(map[*Path]interface{}),
+		visited:  make(map[visit]bool),
+	}
+}
+
+func (d *Diff) diff(aVal, bVal reflect.Value, path Path, opts *opts) bool {
+	// The array underlying `path` could be modified in subsequent
+	// calls. Make sure we have a local copy.
+	localPath := make(Path, len(path))
+	copy(localPath, path)
+
+	// Validity checks. Should only trigger if nil is one of the original arguments.
+	if !aVal.IsValid() && !bVal.IsValid() {
+		return true
+	}
+	if !bVal.IsValid() {
+		d.Modified[&localPath] = nil
+		return false
+	} else if !aVal.IsValid() {
+		d.Modified[&localPath] = bVal.Interface()
+		return false
+	}
+
+	if aVal.Type() != bVal.Type() {
+		d.Modified[&localPath] = bVal.Interface()
+		return false
+	}
+	kind := aVal.Kind()
+
+	// Borrowed from the reflect package to handle recursive data structures.
+	hard := func(k reflect.Kind) bool {
+		switch k {
+		case reflect.Array, reflect.Map, reflect.Slice, reflect.Struct:
+			return true
+		}
+		return false
+	}
+
+	if aVal.CanAddr() && bVal.CanAddr() && hard(kind) {
+		addr1 := unsafe.Pointer(aVal.UnsafeAddr())
+		addr2 := unsafe.Pointer(bVal.UnsafeAddr())
+		if uintptr(addr1) > uintptr(addr2) {
+			// Canonicalize order to reduce number of entries in visited.
+			// Assumes non-moving garbage collector.
+			addr1, addr2 = addr2, addr1
+		}
+
+		// Short circuit if references are already seen.
+		typ := aVal.Type()
+		v := visit{addr1, addr2, typ}
+		if d.visited[v] {
+			return true
+		}
+
+		// Remember for later.
+		d.visited[v] = true
+	}
+	// End of borrowed code.
+
+	equal := true
+	switch kind {
+	case reflect.Map, reflect.Ptr, reflect.Func, reflect.Chan, reflect.Slice:
+		if aVal.IsNil() && bVal.IsNil() {
+			return true
+		}
+		if aVal.IsNil() || bVal.IsNil() {
+			d.Modified[&localPath] = bVal.Interface()
+			return false
+		}
+	}
+
+	switch kind {
+	case reflect.Array, reflect.Slice:
+		aLen := aVal.Len()
+		bLen := bVal.Len()
+		for i := 0; i < min(aLen, bLen); i++ {
+			localPath := append(localPath, SliceIndex(i))
+			if eq := d.diff(aVal.Index(i), bVal.Index(i), localPath, opts); !eq {
+				equal = false
+			}
+		}
+		if aLen > bLen {
+			for i := bLen; i < aLen; i++ {
+				localPath := append(localPath, SliceIndex(i))
+				d.Removed[&localPath] = aVal.Index(i).Interface()
+				equal = false
+			}
+		} else if aLen < bLen {
+			for i := aLen; i < bLen; i++ {
+				localPath := append(localPath, SliceIndex(i))
+				d.Added[&localPath] = bVal.Index(i).Interface()
+				equal = false
+			}
+		}
+	case reflect.Map:
+		for _, key := range aVal.MapKeys() {
+			aI := aVal.MapIndex(key)
+			bI := bVal.MapIndex(key)
+			localPath := append(localPath, MapKey{key.Interface()})
+			if !bI.IsValid() {
+				d.Removed[&localPath] = aI.Interface()
+				equal = false
+			} else if eq := d.diff(aI, bI, localPath, opts); !eq {
+				equal = false
+			}
+		}
+		for _, key := range bVal.MapKeys() {
+			aI := aVal.MapIndex(key)
+			if !aI.IsValid() {
+				bI := bVal.MapIndex(key)
+				localPath := append(localPath, MapKey{key.Interface()})
+				d.Added[&localPath] = bI.Interface()
+				equal = false
+			}
+		}
+	case reflect.Struct:
+		typ := aVal.Type()
+		// If the field is time.Time, use Equal to compare
+		if typ.String() == "time.Time" {
+			aTime := aVal.Interface().(time.Time)
+			bTime := bVal.Interface().(time.Time)
+			if !aTime.Equal(bTime) {
+				d.Modified[&localPath] = bVal.Interface().(time.Time).String()
+				equal = false
+			}
+		} else {
+			for i := 0; i < typ.NumField(); i++ {
+				index := []int{i}
+				field := typ.FieldByIndex(index)
+				if field.Tag.Get("testdiff") == "ignore" { // skip fields marked to be ignored
+					continue
+				}
+				if _, skip := opts.ignoreField[field.Name]; skip {
+					continue
+				}
+				localPath := append(localPath, StructField(field.Name))
+				aI := unsafeReflectValue(aVal.FieldByIndex(index))
+				bI := unsafeReflectValue(bVal.FieldByIndex(index))
+				if eq := d.diff(aI, bI, localPath, opts); !eq {
+					equal = false
+				}
+			}
+		}
+	case reflect.Ptr:
+		equal = d.diff(aVal.Elem(), bVal.Elem(), localPath, opts)
+	default:
+		if reflect.DeepEqual(aVal.Interface(), bVal.Interface()) {
+			equal = true
+		} else {
+			d.Modified[&localPath] = bVal.Interface()
+			equal = false
+		}
+	}
+	return equal
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// During deepValueEqual, must keep track of checks that are
+// in progress.  The comparison algorithm assumes that all
+// checks in progress are true when it reencounters them.
+// Visited comparisons are stored in a map indexed by visit.
+// This is borrowed from the reflect package.
+type visit struct {
+	a1  unsafe.Pointer
+	a2  unsafe.Pointer
+	typ reflect.Type
+}
+
+// Diff represents a change in a struct.
+type Diff struct {
+	Added, Removed, Modified map[*Path]interface{}
+	visited                  map[visit]bool
+}
+
+// Path represents a path to a changed datum.
+type Path []PathNode
+
+func (p Path) String() string {
+	var out string
+	for _, n := range p {
+		out += n.String()
+	}
+	return out
+}
+
+// PathNode represents one step in the path.
+type PathNode interface {
+	String() string
+}
+
+// StructField is a path element representing a field of a struct.
+type StructField string
+
+func (n StructField) String() string {
+	return fmt.Sprintf(".%s", string(n))
+}
+
+// MapKey is a path element representing a key of a map.
+type MapKey struct {
+	Key interface{}
+}
+
+func (n MapKey) String() string {
+	return fmt.Sprintf("[%#v]", n.Key)
+}
+
+// SliceIndex is a path element representing a index of a slice.
+type SliceIndex int
+
+func (n SliceIndex) String() string {
+	return fmt.Sprintf("[%d]", n)
+}
+
+type opts struct {
+	ignoreField map[string]struct{}
+}
+
+// Option is an option to specify in diff
+type Option interface {
+	apply(*opts)
+}
+
+// IgnoreStructField return an option of IgnoreFieldOption
+func IgnoreStructField(field string) Option {
+	return IgnoreFieldOption{
+		Field: field,
+	}
+}
+
+// IgnoreFieldOption is an option for specifying a field that does not diff
+type IgnoreFieldOption struct {
+	Field string
+}
+
+func (i IgnoreFieldOption) apply(opts *opts) {
+	if opts.ignoreField == nil {
+		opts.ignoreField = map[string]struct{}{}
+	}
+	opts.ignoreField[i.Field] = struct{}{}
+}


### PR DESCRIPTION
- Add diff utility for test utils (messagediff.v1) and remove TODO
- Add DeepEqual methods (instead of passing empty values to
`CheckErrorAndDeepEqual`)
- Fix typo in `isFixAvailable` and create a common method to extract
project name from image.

Signed-off-by: liron <liron@twistlock.com>