### PR TITLE
Leewalter tip gpg hung1

### DIFF
--- a/install.md
+++ b/install.md
@@ -33,9 +33,7 @@ gcloud projects list
 
 ## Step #2: Enable the requisite API's for your Google Cloud Project
 
-NOTE: Your account must be whitelisted to enable the Container Analysis API. To do so, join the  [Container Analysis Users Group](https://groups.google.com/forum/#!forum/containeranalysis-users). It may take 1-5 business days to approve the request.
-
-Once approved, enable the necessary API's:
+Enable the necessary API's:
 
 Enable the Container Analysis API:
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -44,6 +44,8 @@ Note: Please create a key with Empty Passphase. We are working on adding support
 ```shell
 gpg --quick-generate-key --yes my.attestator@example.com
 
+(if you use Ubuntu on GCP and got hung in above, then please see https://delightlylinux.wordpress.com/2015/07/01/is-gpg-hanging-when-generating-a-key/ to make sure you got enough entropy.)
+
 gpg --armor --export my.attestator@example.com > gpg.pub
 
 gpg --armor --export-secret-keys my.attestator@example.com > gpg.priv

--- a/tutorial.md
+++ b/tutorial.md
@@ -44,12 +44,12 @@ Note: Please create a key with Empty Passphase. We are working on adding support
 ```shell
 gpg --quick-generate-key --yes my.attestator@example.com
 
-(if you use Ubuntu on GCP and got hung in above, then please see https://delightlylinux.wordpress.com/2015/07/01/is-gpg-hanging-when-generating-a-key/ to make sure you got enough entropy.)
-
 gpg --armor --export my.attestator@example.com > gpg.pub
 
 gpg --armor --export-secret-keys my.attestator@example.com > gpg.priv
 ```
+(if you use Ubuntu on GCP and got hung in above, then please see https://delightlylinux.wordpress.com/2015/07/01/is-gpg-hanging-when-generating-a-key/ to make sure you got enough entropy.)
+
 Create a secret using the exported public and private keys
 ```shell
 kubectl create secret generic my-attestator --from-file=public=gpg.pub --from-file=private=gpg.priv


### PR DESCRIPTION
try to add a tip when gpg hung at quick-create-key because of insufficient entropy in Ubuntu on GCP.
It also has another suggestion in PR 
https://github.com/grafeas/kritis/pull/288