### PR TITLE
Add grafeas support - v1

### DIFF
--- a/pkg/kritis/admission/admission_test.go
+++ b/pkg/kritis/admission/admission_test.go
@@ -82,8 +82,10 @@ func Test_AdmissionResponse(t *testing.T) {
 				return testutil.NewReviewer(tc.reviewErr, tc.expectedMsg)
 			}
 			mockConfig := config{
-				retrievePod:                mockValidPod(),
-				fetchMetadataClient:        testutil.NilFetcher(),
+				retrievePod: mockValidPod(),
+				fetchMetadataClient: func(config *Config) (metadata.Fetcher, error) {
+					return testutil.NilFetcher()()
+				},
 				fetchImageSecurityPolicies: mockISP,
 				reviewer:                   mReviewer,
 			}
@@ -165,7 +167,7 @@ func PodTestReviewHandler(w http.ResponseWriter, r *http.Request) {
 			},
 		},
 	}
-	reviewPod(pod, admitResponse)
+	reviewPod(pod, admitResponse, &Config{Metadata: constants.ContainerAnalysisMetadata})
 	// Send response
 	w.Header().Set("Content-Type", "application/json")
 	payload, err := json.Marshal(admitResponse)

--- a/pkg/kritis/admission/constants/constants.go
+++ b/pkg/kritis/admission/constants/constants.go
@@ -45,3 +45,9 @@ var (
 	// SupportedTypes is a list of Kubernetes types that kritis can validate
 	SupportedTypes = []string{Pod, ReplicaSet, Deployment}
 )
+
+// Types of supported metadata fetchers
+const (
+	GrafeasMetadata           = "grafeas"
+	ContainerAnalysisMetadata = "containerAnalysis"
+)

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
@@ -88,14 +88,14 @@ func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error while creating Occurence %v", err)
 	}
-	expectedPgpKeyId, err := attestation.GetKeyFingerprint(pub)
+	expectedPgpKeyID, err := attestation.GetKeyFingerprint(pub)
 	if err != nil {
 		t.Fatalf("Unexpected error while extracting PGP key id %v", err)
 	}
 
-	pgpKeyId := occ.GetAttestation().GetAttestation().GetPgpSignedAttestation().GetPgpKeyId()
-	if pgpKeyId != expectedPgpKeyId {
-		t.Errorf("Expected PGP key id: %q, got %q", expectedPgpKeyId, pgpKeyId)
+	pgpKeyID := occ.GetAttestation().GetAttestation().GetPgpSignedAttestation().GetPgpKeyId()
+	if pgpKeyID != expectedPgpKeyID {
+		t.Errorf("Expected PGP key id: %q, got %q", expectedPgpKeyID, pgpKeyID)
 	}
 	defer d.DeleteOccurrence(occ.GetName())
 	occurrences, err := d.Attestations(testutil.IntTestImage)

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_test.go
@@ -17,71 +17,10 @@ limitations under the License.
 package containeranalysis
 
 import (
-	"reflect"
 	"testing"
 
-	"github.com/grafeas/kritis/pkg/kritis/metadata"
 	"github.com/grafeas/kritis/pkg/kritis/testutil"
-	"google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1/grafeas"
-	pkg "google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1/package"
-	"google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1/vulnerability"
 )
-
-func TestGetVulnerabilityFromOccurence(t *testing.T) {
-	tests := []struct {
-		name        string
-		severity    vulnerability.Severity
-		fixKind     pkg.Version_VersionKind
-		noteName    string
-		expectedVul metadata.Vulnerability
-	}{
-		{"fix available", vulnerability.Severity_LOW,
-			pkg.Version_MAXIMUM,
-			"CVE-1",
-			metadata.Vulnerability{
-				CVE:             "CVE-1",
-				Severity:        "LOW",
-				HasFixAvailable: false,
-			},
-		},
-		{"fix not available", vulnerability.Severity_MEDIUM,
-			pkg.Version_NORMAL,
-			"CVE-2",
-			metadata.Vulnerability{
-				CVE:             "CVE-2",
-				Severity:        "MEDIUM",
-				HasFixAvailable: true,
-			},
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			vulnDetails := &grafeas.Occurrence_Vulnerability{
-				Vulnerability: &vulnerability.Details{
-					Severity: tc.severity,
-					PackageIssue: []*vulnerability.PackageIssue{
-						{
-							AffectedLocation: &vulnerability.VulnerabilityLocation{},
-							FixedLocation: &vulnerability.VulnerabilityLocation{
-								Version: &pkg.Version{
-									Kind: tc.fixKind,
-								},
-							},
-						},
-					},
-				}}
-			occ := &grafeas.Occurrence{
-				NoteName: tc.noteName,
-				Details:  vulnDetails,
-			}
-
-			actualVuln := getVulnerabilityFromOccurence(occ)
-			if !reflect.DeepEqual(*actualVuln, tc.expectedVul) {
-				t.Fatalf("Expected \n%v\nGot \n%v", tc.expectedVul, actualVuln)
-			}
-		})
-	}
-}
 
 func Test_isRegistryGCR(t *testing.T) {
 	tests := []struct {
@@ -151,10 +90,4 @@ func TestGetProjectFromNoteRef(t *testing.T) {
 			testutil.CheckErrorAndDeepEqual(t, tc.shdErr, err, tc.output, actual)
 		})
 	}
-}
-
-func TestGetResource(t *testing.T) {
-	r := getResource("gcr.io/test/image:sha")
-	e := &grafeas.Resource{Uri: "https://gcr.io/test/image:sha"}
-	testutil.DeepEqual(t, e, r)
 }

--- a/pkg/kritis/metadata/grafeas/grafeas.go
+++ b/pkg/kritis/metadata/grafeas/grafeas.go
@@ -14,57 +14,64 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package containeranalysis
+package grafeas
 
 import (
 	"fmt"
-	"strings"
+	"net"
+	"time"
 
-	ca "cloud.google.com/go/containeranalysis/apiv1beta1"
-	"github.com/golang/glog"
-	"github.com/google/go-containerregistry/pkg/name"
 	kritisv1beta1 "github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
 	"github.com/grafeas/kritis/pkg/kritis/constants"
 	"github.com/grafeas/kritis/pkg/kritis/metadata"
 	"github.com/grafeas/kritis/pkg/kritis/secrets"
 	"github.com/grafeas/kritis/pkg/kritis/util"
 	"golang.org/x/net/context"
-	"google.golang.org/api/iterator"
 	"google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1/attestation"
 	"google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1/grafeas"
+	"google.golang.org/grpc"
 )
 
-// Container Analysis Library Specific Constants.
 const (
 	PkgVulnerability     = "PACKAGE_VULNERABILITY"
 	AttestationAuthority = "ATTESTATION_AUTHORITY"
+	DefaultProject       = "kritis" // DefaultProject is the default project name, only single project is supported
 )
 
-// Client struct implements Fetcher Interface.
+var (
+	// socketPath is the default grafeas socket path
+	socketPath = "/var/run/grafeas.sock"
+)
+
+// Client implements the Fetcher interface using grafeas API.
 type Client struct {
-	client *ca.GrafeasV1Beta1Client
+	client grafeas.GrafeasV1Beta1Client
 	ctx    context.Context
 }
 
 func New() (*Client, error) {
 	ctx := context.Background()
-	client, err := ca.NewGrafeasV1Beta1Client(ctx)
+	conn, err := grpc.Dial(socketPath,
+		grpc.WithInsecure(),
+		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
+			return net.DialTimeout("unix", addr, timeout)
+		}))
 	if err != nil {
 		return nil, err
 	}
 	return &Client{
-		client: client,
+		client: grafeas.NewGrafeasV1Beta1Client(conn),
 		ctx:    ctx,
 	}, nil
 }
 
-//Vulnerabilities gets Package Vulnerabilities Occurrences for a specified image.
+// Vulnerabilities gets Package Vulnerabilities Occurrences for a specified image.
 func (c Client) Vulnerabilities(containerImage string) ([]metadata.Vulnerability, error) {
 	occs, err := c.fetchOccurrence(containerImage, PkgVulnerability)
 	if err != nil {
 		return nil, err
 	}
-	vulnz := []metadata.Vulnerability{}
+	var vulnz []metadata.Vulnerability
 	for _, occ := range occs {
 		if v := util.GetVulnerabilityFromOccurrence(occ); v != nil {
 			vulnz = append(vulnz, *v)
@@ -73,7 +80,7 @@ func (c Client) Vulnerabilities(containerImage string) ([]metadata.Vulnerability
 	return vulnz, nil
 }
 
-//Attestations gets AttesationAuthority Occurrences for a specified image.
+// Attestations gets AttesationAuthority Occurrences for a specified image.
 func (c Client) Attestations(containerImage string) ([]metadata.PGPAttestation, error) {
 	occs, err := c.fetchOccurrence(containerImage, AttestationAuthority)
 	if err != nil {
@@ -86,72 +93,15 @@ func (c Client) Attestations(containerImage string) ([]metadata.PGPAttestation, 
 	return p, nil
 }
 
-func (c Client) fetchOccurrence(containerImage string, kind string) ([]*grafeas.Occurrence, error) {
-	// Make sure container image valid and is a GCR image
-	if !isValidImageOnGCR(containerImage) {
-		return nil, fmt.Errorf("%s is not a valid image hosted in GCR", containerImage)
-	}
-	req := &grafeas.ListOccurrencesRequest{
-		Filter:   fmt.Sprintf("resource_url=%q AND kind=%q", util.GetResourceURL(containerImage), kind),
-		PageSize: constants.PageSize,
-		Parent:   fmt.Sprintf("projects/%s", getProjectFromContainerImage(containerImage)),
-	}
-	it := c.client.ListOccurrences(c.ctx, req)
-	occs := []*grafeas.Occurrence{}
-	for {
-		occ, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
-		occs = append(occs, occ)
-	}
-	return occs, nil
-}
-
-func isValidImageOnGCR(containerImage string) bool {
-	ref, err := name.ParseReference(containerImage, name.WeakValidation)
-	if err != nil {
-		glog.Warning(err)
-		return false
-	}
-	return isRegistryGCR(ref.Context().RegistryStr())
-}
-
-func isRegistryGCR(r string) bool {
-	registry := strings.Split(r, ".")
-	if len(registry) < 2 {
-		return false
-	}
-	if registry[len(registry)-2] != "gcr" || registry[len(registry)-1] != "io" {
-		return false
-	}
-	return true
-}
-
-func getProjectFromNoteReference(ref string) (string, error) {
-	str := strings.Split(ref, "/")
-	if len(str) < 3 {
-		return "", fmt.Errorf("invalid Note Reference. should be in format <api>/projects/<project_id>")
-	}
-	return str[2], nil
-}
-
 // CreateAttestationNote creates an attestation note from AttestationAuthority
 func (c Client) CreateAttestationNote(aa *kritisv1beta1.AttestationAuthority) (*grafeas.Note, error) {
-	noteProject, err := getProjectFromNoteReference(aa.Spec.NoteReference)
-	if err != nil {
-		return nil, err
-	}
 	aaNote := &attestation.Authority{
 		Hint: &attestation.Authority_Hint{
 			HumanReadableName: aa.Name,
 		},
 	}
 	note := grafeas.Note{
-		Name:             fmt.Sprintf("projects/%s/notes/%s", noteProject, aa.Name),
+		Name:             fmt.Sprintf("projects/%s/notes/%s", DefaultProject, aa.Name),
 		ShortDescription: fmt.Sprintf("Image Policy Security Attestor"),
 		LongDescription:  fmt.Sprintf("Image Policy Security Attestor deployed in %s namespace", aa.Namespace),
 		Type: &grafeas.Note_AttestationAuthority{
@@ -162,19 +112,15 @@ func (c Client) CreateAttestationNote(aa *kritisv1beta1.AttestationAuthority) (*
 	req := &grafeas.CreateNoteRequest{
 		Note:   &note,
 		NoteId: aa.Name,
-		Parent: fmt.Sprintf("projects/%s", noteProject),
+		Parent: fmt.Sprintf("projects/%s", DefaultProject),
 	}
 	return c.client.CreateNote(c.ctx, req)
 }
 
 //AttestationNote returns a note if it exists for given AttestationAuthority
 func (c Client) AttestationNote(aa *kritisv1beta1.AttestationAuthority) (*grafeas.Note, error) {
-	noteProject, err := getProjectFromNoteReference(aa.Spec.NoteReference)
-	if err != nil {
-		return nil, err
-	}
 	req := &grafeas.GetNoteRequest{
-		Name: fmt.Sprintf("projects/%s/notes/%s", noteProject, aa.Name),
+		Name: fmt.Sprintf("projects/%s/notes/%s", DefaultProject, aa.Name),
 	}
 	return c.client.GetNote(c.ctx, req)
 }
@@ -183,9 +129,6 @@ func (c Client) AttestationNote(aa *kritisv1beta1.AttestationAuthority) (*grafea
 func (c Client) CreateAttestationOccurence(note *grafeas.Note,
 	containerImage string,
 	pgpSigningKey *secrets.PGPSigningSecret) (*grafeas.Occurrence, error) {
-	if !isValidImageOnGCR(containerImage) {
-		return nil, fmt.Errorf("%s is not a valid image hosted in GCR", containerImage)
-	}
 	fingerprint, err := util.GetAttestationKeyFingerprint(pgpSigningKey)
 	if err != nil {
 		return nil, fmt.Errorf("Can't get fingerprint from PGP siging key %s: %v", pgpSigningKey.SecretName, err)
@@ -217,41 +160,33 @@ func (c Client) CreateAttestationOccurence(note *grafeas.Note,
 		NoteName: note.GetName(),
 		Details:  attestationDetails,
 	}
-	// Create the AttestationAuthrity Occurrence in the Project AttestationAuthority Note.
+	// Create the AttestationAuthority Occurrence in the Project AttestationAuthority Note.
 	req := &grafeas.CreateOccurrenceRequest{
 		Occurrence: occ,
-		Parent:     fmt.Sprintf("projects/%s", getProjectFromContainerImage(containerImage)),
+		Parent:     fmt.Sprintf("projects/%s", DefaultProject),
 	}
-	// Call create Occurrence Api
 	return c.client.CreateOccurrence(c.ctx, req)
 }
 
-func getProjectFromContainerImage(image string) string {
-	tok := strings.Split(image, "/")
-	if len(tok) < 2 {
-		return ""
+func (c Client) fetchOccurrence(containerImage string, kind string) ([]*grafeas.Occurrence, error) {
+	req := &grafeas.ListOccurrencesRequest{
+		Filter:   fmt.Sprintf("resource_url=%q AND kind=%q", util.GetResourceURL(containerImage), kind),
+		PageSize: constants.PageSize,
+		Parent:   fmt.Sprintf("projects/%s", DefaultProject),
 	}
-	return tok[1]
-}
-
-// The following methods are used for Testing
-
-// DeleteAttestationNote deletes a note for given AttestationAuthority
-func (c Client) DeleteAttestationNote(aa *kritisv1beta1.AttestationAuthority) error {
-	noteProject, err := getProjectFromNoteReference(aa.Spec.NoteReference)
-	if err != nil {
-		return err
+	var occs []*grafeas.Occurrence
+	var nextPageToken string
+	for {
+		req.PageToken = nextPageToken
+		resp, err := c.client.ListOccurrences(c.ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		occs = append(occs, resp.Occurrences...)
+		nextPageToken = resp.NextPageToken
+		if len(occs) == 0 || nextPageToken == "" {
+			break
+		}
 	}
-	req := &grafeas.DeleteNoteRequest{
-		Name: fmt.Sprintf("projects/%s/notes/%s", noteProject, aa.Name),
-	}
-	return c.client.DeleteNote(c.ctx, req)
-}
-
-// DeleteOccurrence deletes an occurrence with given ID
-func (c Client) DeleteOccurrence(ID string) error {
-	req := &grafeas.DeleteOccurrenceRequest{
-		Name: ID,
-	}
-	return c.client.DeleteOccurrence(c.ctx, req)
+	return occs, nil
 }

--- a/pkg/kritis/metadata/grafeas/grafeas_test.go
+++ b/pkg/kritis/metadata/grafeas/grafeas_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package grafeas
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	kritisv1beta1 "github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
+	"github.com/grafeas/kritis/pkg/kritis/attestation"
+	"github.com/grafeas/kritis/pkg/kritis/secrets"
+	"github.com/grafeas/kritis/pkg/kritis/testutil"
+	"google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1/grafeas"
+	"google.golang.org/grpc"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
+	socketPath = ".grafeas.sock"
+	server := grpc.NewServer()
+	grafeasMock := newGrafeasServerMock()
+	lis, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Failed to listen on socket %v", err)
+	}
+	_, err = os.Stat(socketPath)
+	t.Logf("File %v", err)
+	grafeas.RegisterGrafeasV1Beta1Server(server, grafeasMock)
+	go func() {
+		if err := server.Serve(lis); err != nil {
+			t.Fatalf("Failed to server %v", err)
+		}
+	}()
+	defer func() {
+		server.GracefulStop()
+		os.Remove(socketPath)
+	}()
+	client, err := New()
+	if err != nil {
+		t.Fatalf("Could not initialize the client %v", err)
+	}
+	aa := &kritisv1beta1.AttestationAuthority{
+		Spec: kritisv1beta1.AttestationAuthoritySpec{
+			NoteReference: fmt.Sprintf("%s/projects/%s", "api", DefaultProject),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "note1",
+		},
+	}
+	if _, err := client.CreateAttestationNote(aa); err != nil {
+		t.Fatalf("Unexpected error while creating Note %v", err)
+	}
+	note, err := client.AttestationNote(aa)
+	if err != nil {
+		t.Fatalf("Unexpected no error while getting attestation note %v", err)
+	}
+	expectedNoteName := fmt.Sprintf("projects/%s/notes/note1", DefaultProject)
+	if note.Name != expectedNoteName {
+		t.Fatalf("Expected %s.\n Got %s", expectedNoteName, note.Name)
+	}
+	actualHint := note.GetAttestationAuthority().Hint.GetHumanReadableName()
+	if actualHint != "note1" {
+		t.Fatalf("Expected %s.\n Got %s", expectedNoteName, actualHint)
+	}
+	// Test Create Attestation Occurrence
+	pub, priv := testutil.CreateKeyPair(t, "test")
+	secret := &secrets.PGPSigningSecret{
+		PrivateKey: priv,
+		PublicKey:  pub,
+		SecretName: "test",
+	}
+	occ, err := client.CreateAttestationOccurence(note, testutil.IntTestImage, secret)
+	if err != nil {
+		t.Fatalf("Unexpected error while creating Occurence %v", err)
+	}
+	expectedPgpKeyID, err := attestation.GetKeyFingerprint(pub)
+	if err != nil {
+		t.Fatalf("Unexpected error while extracting PGP key id %v", err)
+	}
+
+	pgpKeyID := occ.GetAttestation().GetAttestation().GetPgpSignedAttestation().GetPgpKeyId()
+	if pgpKeyID != expectedPgpKeyID {
+		t.Errorf("Expected PGP key id: %q, got %q", expectedPgpKeyID, pgpKeyID)
+	}
+	occurrences, err := client.Attestations(testutil.IntTestImage)
+	if err != nil {
+		t.Fatalf("Unexpected error while listing Occ %v", err)
+	}
+	if occurrences == nil {
+		t.Fatal("Shd have created atleast 1 occurrence")
+	}
+}
+
+// grafeasServerMock is a mock for grafeas grpc API
+type grafeasServerMock struct {
+	notes       map[string]*grafeas.Note
+	occurrences map[string]*grafeas.Occurrence
+}
+
+func newGrafeasServerMock() *grafeasServerMock {
+	return &grafeasServerMock{notes: make(map[string]*grafeas.Note), occurrences: make(map[string]*grafeas.Occurrence)}
+}
+
+func (g *grafeasServerMock) GetOccurrence(ctx context.Context, req *grafeas.GetOccurrenceRequest) (*grafeas.Occurrence, error) {
+	return g.occurrences[req.Name], nil
+}
+
+func (g *grafeasServerMock) ListOccurrences(context.Context, *grafeas.ListOccurrencesRequest) (*grafeas.ListOccurrencesResponse, error) {
+	var resp grafeas.ListOccurrencesResponse
+	for _, occ := range g.occurrences {
+		resp.Occurrences = append(resp.Occurrences, occ)
+	}
+	return &resp, nil
+}
+
+func (g *grafeasServerMock) DeleteOccurrence(context.Context, *grafeas.DeleteOccurrenceRequest) (*empty.Empty, error) {
+	return nil, nil
+}
+
+func (g *grafeasServerMock) CreateOccurrence(ctx context.Context, req *grafeas.CreateOccurrenceRequest) (*grafeas.Occurrence, error) {
+	occ := req.Occurrence
+	g.occurrences[occ.Name] = occ
+	return occ, nil
+}
+
+func (g *grafeasServerMock) BatchCreateOccurrences(context.Context, *grafeas.BatchCreateOccurrencesRequest) (*grafeas.BatchCreateOccurrencesResponse, error) {
+	return nil, nil
+}
+
+func (g *grafeasServerMock) UpdateOccurrence(context.Context, *grafeas.UpdateOccurrenceRequest) (*grafeas.Occurrence, error) {
+	return nil, nil
+}
+
+func (g *grafeasServerMock) GetOccurrenceNote(context.Context, *grafeas.GetOccurrenceNoteRequest) (*grafeas.Note, error) {
+	return nil, nil
+}
+
+func (g *grafeasServerMock) GetNote(ctx context.Context, req *grafeas.GetNoteRequest) (*grafeas.Note, error) {
+	return g.notes[req.Name], nil
+}
+
+func (g *grafeasServerMock) ListNotes(context.Context, *grafeas.ListNotesRequest) (*grafeas.ListNotesResponse, error) {
+	return nil, nil
+}
+
+func (g *grafeasServerMock) DeleteNote(context.Context, *grafeas.DeleteNoteRequest) (*empty.Empty, error) {
+	return nil, nil
+}
+
+func (g *grafeasServerMock) CreateNote(ctx context.Context, req *grafeas.CreateNoteRequest) (*grafeas.Note, error) {
+	note := req.Note
+	g.notes[note.Name] = note
+	return note, nil
+}
+
+func (g *grafeasServerMock) BatchCreateNotes(context.Context, *grafeas.BatchCreateNotesRequest) (*grafeas.BatchCreateNotesResponse, error) {
+	return nil, nil
+}
+
+func (g *grafeasServerMock) UpdateNote(context.Context, *grafeas.UpdateNoteRequest) (*grafeas.Note, error) {
+	return nil, nil
+}
+
+func (g *grafeasServerMock) ListNoteOccurrences(context.Context, *grafeas.ListNoteOccurrencesRequest) (*grafeas.ListNoteOccurrencesResponse, error) {
+	return nil, nil
+}
+
+func (g *grafeasServerMock) GetVulnerabilityOccurrencesSummary(context.Context, *grafeas.GetVulnerabilityOccurrencesSummaryRequest) (*grafeas.VulnerabilityOccurrencesSummary, error) {
+	return nil, nil
+}

--- a/pkg/kritis/metadata/metadata.go
+++ b/pkg/kritis/metadata/metadata.go
@@ -19,20 +19,20 @@ package metadata
 import (
 	kritisv1beta1 "github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
 	"github.com/grafeas/kritis/pkg/kritis/secrets"
-	"google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1/grafeas"
+	grafeasv1beta1 "google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1/grafeas"
 )
 
 type Fetcher interface {
 	// Vulnerabilities returns package vulnerabilities for a given image.
 	Vulnerabilities(containerImage string) ([]Vulnerability, error)
 	// Create Attesatation Occurrence for an image.
-	CreateAttestationOccurence(note *grafeas.Note,
+	CreateAttestationOccurence(note *grafeasv1beta1.Note,
 		containerImage string,
-		pgpSigningKey *secrets.PGPSigningSecret) (*grafeas.Occurrence, error)
+		pgpSigningKey *secrets.PGPSigningSecret) (*grafeasv1beta1.Occurrence, error)
 	//AttestationNote getches a Attestation note for an Attestation Authority.
-	AttestationNote(aa *kritisv1beta1.AttestationAuthority) (*grafeas.Note, error)
+	AttestationNote(aa *kritisv1beta1.AttestationAuthority) (*grafeasv1beta1.Note, error)
 	// Create Attestation Note for an Attestation Authority.
-	CreateAttestationNote(aa *kritisv1beta1.AttestationAuthority) (*grafeas.Note, error)
+	CreateAttestationNote(aa *kritisv1beta1.AttestationAuthority) (*grafeasv1beta1.Note, error)
 	//Attestations get Attestation Occurrences for given image.
 	Attestations(containerImage string) ([]PGPAttestation, error)
 }

--- a/pkg/kritis/util/util_test.go
+++ b/pkg/kritis/util/util_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package util
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/grafeas/kritis/pkg/kritis/metadata"
+	"github.com/grafeas/kritis/pkg/kritis/testutil"
+	"google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1/grafeas"
+	pkg "google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1/package"
+	"google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1/vulnerability"
+)
+
+func TestGetVulnerabilityFromOccurence(t *testing.T) {
+	tests := []struct {
+		name        string
+		severity    vulnerability.Severity
+		fixKind     pkg.Version_VersionKind
+		noteName    string
+		expectedVul metadata.Vulnerability
+	}{
+		{"fix available", vulnerability.Severity_LOW,
+			pkg.Version_MAXIMUM,
+			"CVE-1",
+			metadata.Vulnerability{
+				CVE:             "CVE-1",
+				Severity:        "LOW",
+				HasFixAvailable: false,
+			},
+		},
+		{"fix not available", vulnerability.Severity_MEDIUM,
+			pkg.Version_NORMAL,
+			"CVE-2",
+			metadata.Vulnerability{
+				CVE:             "CVE-2",
+				Severity:        "MEDIUM",
+				HasFixAvailable: true,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vulnDetails := &grafeas.Occurrence_Vulnerability{
+				Vulnerability: &vulnerability.Details{
+					Severity: tc.severity,
+					PackageIssue: []*vulnerability.PackageIssue{
+						{
+							AffectedLocation: &vulnerability.VulnerabilityLocation{},
+							FixedLocation: &vulnerability.VulnerabilityLocation{
+								Version: &pkg.Version{
+									Kind: tc.fixKind,
+								},
+							},
+						},
+					},
+				}}
+			occ := &grafeas.Occurrence{
+				NoteName: tc.noteName,
+				Details:  vulnDetails,
+			}
+
+			actualVuln := GetVulnerabilityFromOccurrence(occ)
+			if !reflect.DeepEqual(*actualVuln, tc.expectedVul) {
+				t.Fatalf("Expected \n%v\nGot \n%v", tc.expectedVul, actualVuln)
+			}
+		})
+	}
+}
+
+func TestGetResource(t *testing.T) {
+	r := GetResource("gcr.io/test/image:sha")
+	e := &grafeas.Resource{Uri: "https://gcr.io/test/image:sha"}
+	testutil.DeepEqual(t, e, r)
+}


### PR DESCRIPTION
## Changes
1. Implements the `Fetcher` API using grafeas beta client (remark:
grafeas project has recently gone migration from v1alpha1 to b1beta1,
grafeas/grafeas#220)
2. Move common functions to `util.go`
## Solution caveats
The current implementation has the follow caveats:
    1. Only a single project is supported
    2. Connection to grafeas is only via unix socket (supported after
grafeas/grafeas#220)

## Next steps:
1. Enable specifying a grafeas setting config (client certs and URL)
2. More tests and validations
3. Add filtering capabilities to grafeas to support existing kritis queries
(resource url and kind). This will be done in grafeas project.

Signed-off-by: liron <liron@twistlock.com>