### PR TITLE
Added copying of artifacts folder with CRDs

### DIFF
--- a/helm-hooks/Dockerfile
+++ b/helm-hooks/Dockerfile
@@ -26,4 +26,7 @@ ENV KUBECTL_VERSION v1.10.0
 RUN curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl  && \
     chmod +x /usr/local/bin/kubectl
 
-COPY --from=0 /go/src/github.com/grafeas/kritis/out/${stage}  /${stage} 
+COPY --from=0 /go/src/github.com/grafeas/kritis/out/${stage}  /${stage}
+
+# Copy artifacts to the image.
+COPY --from=0 /go/src/github.com/grafeas/kritis/artifacts /${stage}/artifacts

--- a/helm-hooks/Dockerfile
+++ b/helm-hooks/Dockerfile
@@ -29,4 +29,4 @@ RUN curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-re
 COPY --from=0 /go/src/github.com/grafeas/kritis/out/${stage}  /${stage}
 
 # Copy artifacts to the image.
-COPY --from=0 /go/src/github.com/grafeas/kritis/artifacts /${stage}/artifacts
+COPY --from=0 /go/src/github.com/grafeas/kritis/artifacts /artifacts


### PR DESCRIPTION
This will allow us to remove redundant code in https://github.com/grafeas/kritis/blob/master/helm-hooks/preinstall/crd.go that redefines the CRDs. Does a cleanup for #224.