### PR TITLE
Set the BAZEL_VERSION env var

### DIFF
--- a/hack/kokoro-test.sh
+++ b/hack/kokoro-test.sh
@@ -22,6 +22,8 @@ set -euf -x
 
 source "${KOKORO_GFILE_DIR}/common.sh"
 
+BAZEL_VERSION=0.19.2
+
 # Get everything into GOPATH
 sudo mkdir -p "${GOPATH}/src/github.com/grafeas/kritis/"
 CWD=`pwd`


### PR DESCRIPTION
This fixes the integration tests failure with the error message: `common.sh: line 5: BAZEL_VERSION: unbound variable`.