### PR TITLE
Removed setting of BAZEL_VERSION

### DIFF
--- a/hack/kokoro-test.sh
+++ b/hack/kokoro-test.sh
@@ -22,8 +22,6 @@ set -euf -x
 
 source "${KOKORO_GFILE_DIR}/common.sh"
 
-export BAZEL_VERSION=0.19.2
-
 # Get everything into GOPATH
 sudo mkdir -p "${GOPATH}/src/github.com/grafeas/kritis/"
 CWD=`pwd`


### PR DESCRIPTION
The setting of the environment var doesn't actually fix the underlying kokoro failure. The fix was made internally.