### PR TITLE
Fix "scope" position of CRD manifests in helm preinstall hook

### DIFF
--- a/helm-hooks/preinstall/crd.go
+++ b/helm-hooks/preinstall/crd.go
@@ -41,10 +41,10 @@ metadata:
 spec:
     group: kritis.grafeas.io
     version: v1beta1
+    scope: Namespaced
     names:
         kind: ImageSecurityPolicy
-        plural: imagesecuritypolicies
-        scope: Namespaced`
+        plural: imagesecuritypolicies`
 
 	kritisConfigCRD = `apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -55,9 +55,9 @@ metadata:
 spec:
   group: kritis.grafeas.io
   version: v1beta1
+  scope: Cluster
   names:
     kind: KritisConfig
     plural: kritisconfigs
-    singular: kritisconfig
-    scope: Cluster`
+    singular: kritisconfig`
 )


### PR DESCRIPTION
I got an error below when I installed Kritis with Helm chart:
```
time="2019-02-06T01:23:07Z" level=error msg="error: error validating \"STDIN\": error validating data: [ValidationError(CustomResourceDefinition.spec.names): unknown field \"scope\" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionNames, ValidationError(CustomResourceDefinition.spec): missing required field \"scope\" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionSpec]; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2019-02-06T01:23:07Z" level=fatal msg="exit status 1"
```

It caused by invalid CRD manifests in preinstall hook.

This pull request fixes them.
