### PR TITLE
fix yaml syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ imageWhitelist:
 packageVulnerabilityPolicy:
   maximumSeverity: HIGH
   whitelistCVEs:
-    providers/goog-vulnz/notes/CVE-2017-1000082
-    providers/goog-vulnz/notes/CVE-2017-1000082
+    - providers/goog-vulnz/notes/CVE-2017-1000082
+    - providers/goog-vulnz/notes/CVE-2017-1000081
 ```
 
 In addition to the enforcement this project also contains *signers* that can be

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -51,8 +51,8 @@ spec:
   packageVulnerabilityPolicy:
     maximumSeverity: MEDIUM
     whitelistCVEs:
-      providers/goog-vulnz/notes/CVE-2017-1000082
-      providers/goog-vulnz/notes/CVE-2017-1000082
+      - providers/goog-vulnz/notes/CVE-2017-1000082
+      - providers/goog-vulnz/notes/CVE-2017-1000081
 ```
 
 To view the CRD:


### PR DESCRIPTION
`whitelistCVEs` is a slice of string, and so it needs a heading '-' in yaml like [this](https://github.com/grafeas/kritis/blob/master/integration/testdata/image-security-policy/my-isp.yaml#L14-L16).