### PR TITLE
Tweak makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,7 @@ just-the-integration-test:
 		-timeout 30m \
 		-gac-credentials=$(GAC_CREDENTIALS_PATH) \
 		-gcp-project=$(GCP_PROJECT) \
+		-gke-zone=$(GCP_ZONE) \
 		-gke-cluster-name=$(GCP_CLUSTER) $(EXTRA_TEST_FLAGS)
 
 # integration-local requires that "setup-integration-local" has been run at least once.

--- a/Makefile
+++ b/Makefile
@@ -113,13 +113,13 @@ HELM_HOOKS = preinstall postinstall predelete
 $(HELM_HOOKS): $(GO_FILES)
 	GOARCH=$(GOARCH) GOOS=linux CGO_ENABLED=0 go build -ldflags "$(GO_LDFLAGS)" -o out/$@ $(REPOPATH)/helm-hooks/$@
 
-.PHONY: %-image
-%-image: $(HELM_HOOKS)
-	docker build -t $(REGISTRY)/$*:$(IMAGE_TAG) -f helm-hooks/Dockerfile . --build-arg stage=$*
-
 .PHONY: %-test-image
 %-test-image: $(HELM_HOOKS)
 	docker build -t $(TEST_REGISTRY)/$*:$(IMAGE_TAG) -f helm-hooks/Dockerfile . --build-arg stage=$*
+
+.PHONY: %-image
+%-image: $(HELM_HOOKS)
+	docker build -t $(REGISTRY)/$*:$(IMAGE_TAG) -f helm-hooks/Dockerfile . --build-arg stage=$*
 
 .PHONY: helm-release-image
 helm-release-image:


### PR DESCRIPTION
This pull request tweaks the followings:
- Fix Makefile pattern rules order (fix %-test-image never be used)
- Add "-gke-zone=$(GCP_ZONE)" command line option to "just-the-integration-test" make task
