### PR TITLE
Adding BuildPolicy Verification on to Kritis Flow

### DIFF
--- a/pkg/kritis/gcbsigner/signer.go
+++ b/pkg/kritis/gcbsigner/signer.go
@@ -17,8 +17,11 @@ limitations under the License.
 package gcbsigner
 
 import (
+	"encoding/base64"
+
 	"github.com/golang/glog"
 	"github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
+	"github.com/grafeas/kritis/pkg/kritis/container"
 	"github.com/grafeas/kritis/pkg/kritis/crd/authority"
 	"github.com/grafeas/kritis/pkg/kritis/crd/buildpolicy"
 	"github.com/grafeas/kritis/pkg/kritis/metadata"
@@ -59,6 +62,12 @@ var (
 // Returns an error if creating an attestation for any authority fails.
 func (s Signer) ValidateAndSign(prov BuildProvenance, bps []v1beta1.BuildPolicy) error {
 	for _, bp := range bps {
+		// If Image already is attested using the AttestationAuthority the Policy, return true.
+		if s.verifyAttestations(prov.ImageRef, bp.Namespace, bp.Spec.AttestationAuthorityName) {
+			glog.Infof("Image %q has valid attestation for BuildPolicy %q", prov.ImageRef, bp.ObjectMeta.Name)
+			return nil
+		}
+
 		glog.Infof("Validating %q against BuildPolicy %q", prov.ImageRef, bp.Name)
 		if result := s.config.Validate(bp, prov.BuiltFrom); result != nil {
 			glog.Errorf("Image %q does not match BuildPolicy %q: %s", prov.ImageRef, bp.ObjectMeta.Name, result)
@@ -70,6 +79,45 @@ func (s Signer) ValidateAndSign(prov BuildProvenance, bps []v1beta1.BuildPolicy)
 		}
 	}
 	return nil
+}
+
+func (s Signer) verifyAttestations(image string, ns string, authority string) bool {
+	// Get AttestaionAuthority specified in the buildpolicy.
+	auth, err := authFetcher(ns, authority)
+	if err != nil {
+		glog.Errorf("Error while fetching authorities %s", err)
+		return false
+	}
+	atts, err := s.client.Attestations(image)
+	if err != nil {
+		glog.Errorf("Error while fetching attestations %s", err)
+		return false
+	}
+	return s.hasValidImageAttestations(image, atts, auth)
+}
+
+// re-use reviewe.Review
+func (s Signer) hasValidImageAttestations(image string, attestations []metadata.PGPAttestation, auth *v1beta1.AttestationAuthority) bool {
+	host, err := container.NewAtomicContainerSig(image, map[string]string{})
+	if err != nil {
+		glog.Error(err)
+		return false
+	}
+	key, fp, err := fingerprint(auth.Spec.PublicKeyData)
+	if err != nil {
+		glog.Errorf("Error parsing key for %q: %v", auth.Name, err)
+		return false
+	}
+	for _, a := range attestations {
+		if a.KeyID == fp {
+			if err = host.VerifyAttestationSignature(key, a.Signature); err != nil {
+				glog.Errorf("Could not find verify attestation for attestation authority %s", a.KeyID)
+			} else {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (s Signer) addAttestation(image string, ns string, authority string) error {
@@ -90,4 +138,18 @@ func (s Signer) addAttestation(image string, ns string, authority string) error 
 	// Create Attestation Signature
 	_, err = s.client.CreateAttestationOccurence(n, image, sec)
 	return err
+}
+
+// fingerprint returns the fingerprint and key from the base64 encoded public key data
+// re-use from review.Review
+func fingerprint(publicKeyData string) (key, fingerprint string, err error) {
+	publicData, err := base64.StdEncoding.DecodeString(publicKeyData)
+	if err != nil {
+		return key, fingerprint, err
+	}
+	s, err := secrets.NewPgpKey("", "", string(publicData))
+	if err != nil {
+		return key, fingerprint, err
+	}
+	return string(publicData), s.Fingerprint(), nil
 }


### PR DESCRIPTION
In this commit,
1. AdmissionConfig declares BuildPolicy Reviewer.
2. The BuildPolicyReview is right now the google cloud build policy
reviewer. This should be replaced by a generic reviewer.
3. Admission flow now reviews BuildPolicy along with ISP
4. The review process for Build Policy is
   a. Fetch all the BuildPolicies in the namespace
   b. Convert container image to google cloud build Provenance struct.
      This needs to go away in future.
   c. Call the policy ValidateAndSign method.
5. ValidateAndSign will first
  - check if valid attestation exists for this container image.
     if it does, it will return immediately which will suffice the use
     case we have now.
  - if no valid attestation is found, it will verify the source of build
  and either deny or allow.

Please remember this is not tested and might need some work.