### PR TITLE
Fixes towards integration of standalone Kritis with standalone Grafeas

### DIFF
--- a/artifacts/examples/kritis-config-example.yaml
+++ b/artifacts/examples/kritis-config-example.yaml
@@ -2,7 +2,6 @@ apiVersion: kritis.grafeas.io/v1beta1
 kind: KritisConfig
 metadata:
   name: kritis-config
-  namespace: default
 spec:
   metadataBackend: containerAnalysis
   cronInterval: 1h

--- a/cmd/kritis/admission/main.go
+++ b/cmd/kritis/admission/main.go
@@ -69,7 +69,7 @@ func main() {
 	}
 
 	// KritisConfig is a cluster-wide CRD.
-	kritisConfigs, err := kritisconfig.KritisConfigs("")
+	kritisConfigs, err := kritisconfig.KritisConfigs()
 	if err != nil {
 		errMsg := fmt.Sprintf("error getting kritis config: %v", err)
 		glog.Errorf(errMsg)
@@ -86,7 +86,7 @@ func main() {
 	}
 
 	if len(kritisConfigs) == 0 {
-		glog.Errorf("No KritisConfigs found in any namespace, will assume the defaults")
+		glog.Infof("No KritisConfigs found in any namespace, will assume the defaults")
 	} else if len(kritisConfigs) > 1 {
 		glog.Errorf("More than 1 KritisConfig found, expected to have only 1 in the cluster")
 		return

--- a/kritis-charts/templates/configmap.yaml
+++ b/kritis-charts/templates/configmap.yaml
@@ -7,5 +7,5 @@ data:
     grafeascerts:
       # PKI configuration
       cafile: /certificates/ca.crt
-      keyfile: /certificates/server.key
-      certfile: /certificates/server.crt
+      keyfile: /certificates/client.key
+      certfile: /certificates/client.crt

--- a/pkg/kritis/apis/kritis/v1beta1/kritisconfig.go
+++ b/pkg/kritis/apis/kritis/v1beta1/kritisconfig.go
@@ -22,6 +22,7 @@ import (
 
 // +genclient
 // +genclient:noStatus
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type KritisConfig struct {
@@ -50,7 +51,7 @@ type GrafeasConfigSpec struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// KritisConfigList is a list of BuildPolicy resources
+// KritisConfigList is a list of KritisConfig resources
 type KritisConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/pkg/kritis/client/clientset/versioned/typed/kritis/v1beta1/fake/fake_kritis_client.go
+++ b/pkg/kritis/client/clientset/versioned/typed/kritis/v1beta1/fake/fake_kritis_client.go
@@ -44,8 +44,8 @@ func (c *FakeKritisV1beta1) ImageSecurityPolicies(namespace string) v1beta1.Imag
 	return &FakeImageSecurityPolicies{c, namespace}
 }
 
-func (c *FakeKritisV1beta1) KritisConfigs(namespace string) v1beta1.KritisConfigInterface {
-	return &FakeKritisConfigs{c, namespace}
+func (c *FakeKritisV1beta1) KritisConfigs() v1beta1.KritisConfigInterface {
+	return &FakeKritisConfigs{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/kritis/client/clientset/versioned/typed/kritis/v1beta1/fake/fake_kritisconfig.go
+++ b/pkg/kritis/client/clientset/versioned/typed/kritis/v1beta1/fake/fake_kritisconfig.go
@@ -31,7 +31,6 @@ import (
 // FakeKritisConfigs implements KritisConfigInterface
 type FakeKritisConfigs struct {
 	Fake *FakeKritisV1beta1
-	ns   string
 }
 
 var kritisconfigsResource = schema.GroupVersionResource{Group: "kritis", Version: "v1beta1", Resource: "kritisconfigs"}
@@ -41,8 +40,7 @@ var kritisconfigsKind = schema.GroupVersionKind{Group: "kritis", Version: "v1bet
 // Get takes name of the kritisConfig, and returns the corresponding kritisConfig object, and an error if there is any.
 func (c *FakeKritisConfigs) Get(name string, options v1.GetOptions) (result *v1beta1.KritisConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(kritisconfigsResource, c.ns, name), &v1beta1.KritisConfig{})
-
+		Invokes(testing.NewRootGetAction(kritisconfigsResource, name), &v1beta1.KritisConfig{})
 	if obj == nil {
 		return nil, err
 	}
@@ -52,8 +50,7 @@ func (c *FakeKritisConfigs) Get(name string, options v1.GetOptions) (result *v1b
 // List takes label and field selectors, and returns the list of KritisConfigs that match those selectors.
 func (c *FakeKritisConfigs) List(opts v1.ListOptions) (result *v1beta1.KritisConfigList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(kritisconfigsResource, kritisconfigsKind, c.ns, opts), &v1beta1.KritisConfigList{})
-
+		Invokes(testing.NewRootListAction(kritisconfigsResource, kritisconfigsKind, opts), &v1beta1.KritisConfigList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -74,15 +71,13 @@ func (c *FakeKritisConfigs) List(opts v1.ListOptions) (result *v1beta1.KritisCon
 // Watch returns a watch.Interface that watches the requested kritisConfigs.
 func (c *FakeKritisConfigs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(kritisconfigsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(kritisconfigsResource, opts))
 }
 
 // Create takes the representation of a kritisConfig and creates it.  Returns the server's representation of the kritisConfig, and an error, if there is any.
 func (c *FakeKritisConfigs) Create(kritisConfig *v1beta1.KritisConfig) (result *v1beta1.KritisConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(kritisconfigsResource, c.ns, kritisConfig), &v1beta1.KritisConfig{})
-
+		Invokes(testing.NewRootCreateAction(kritisconfigsResource, kritisConfig), &v1beta1.KritisConfig{})
 	if obj == nil {
 		return nil, err
 	}
@@ -92,8 +87,7 @@ func (c *FakeKritisConfigs) Create(kritisConfig *v1beta1.KritisConfig) (result *
 // Update takes the representation of a kritisConfig and updates it. Returns the server's representation of the kritisConfig, and an error, if there is any.
 func (c *FakeKritisConfigs) Update(kritisConfig *v1beta1.KritisConfig) (result *v1beta1.KritisConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(kritisconfigsResource, c.ns, kritisConfig), &v1beta1.KritisConfig{})
-
+		Invokes(testing.NewRootUpdateAction(kritisconfigsResource, kritisConfig), &v1beta1.KritisConfig{})
 	if obj == nil {
 		return nil, err
 	}
@@ -103,14 +97,13 @@ func (c *FakeKritisConfigs) Update(kritisConfig *v1beta1.KritisConfig) (result *
 // Delete takes name of the kritisConfig and deletes it. Returns an error if one occurs.
 func (c *FakeKritisConfigs) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(kritisconfigsResource, c.ns, name), &v1beta1.KritisConfig{})
-
+		Invokes(testing.NewRootDeleteAction(kritisconfigsResource, name), &v1beta1.KritisConfig{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeKritisConfigs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(kritisconfigsResource, c.ns, listOptions)
+	action := testing.NewRootDeleteCollectionAction(kritisconfigsResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1beta1.KritisConfigList{})
 	return err
@@ -119,8 +112,7 @@ func (c *FakeKritisConfigs) DeleteCollection(options *v1.DeleteOptions, listOpti
 // Patch applies the patch and returns the patched kritisConfig.
 func (c *FakeKritisConfigs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.KritisConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(kritisconfigsResource, c.ns, name, data, subresources...), &v1beta1.KritisConfig{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(kritisconfigsResource, name, data, subresources...), &v1beta1.KritisConfig{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/kritis/client/clientset/versioned/typed/kritis/v1beta1/kritis_client.go
+++ b/pkg/kritis/client/clientset/versioned/typed/kritis/v1beta1/kritis_client.go
@@ -55,8 +55,8 @@ func (c *KritisV1beta1Client) ImageSecurityPolicies(namespace string) ImageSecur
 	return newImageSecurityPolicies(c, namespace)
 }
 
-func (c *KritisV1beta1Client) KritisConfigs(namespace string) KritisConfigInterface {
-	return newKritisConfigs(c, namespace)
+func (c *KritisV1beta1Client) KritisConfigs() KritisConfigInterface {
+	return newKritisConfigs(c)
 }
 
 // NewForConfig creates a new KritisV1beta1Client for the given config.

--- a/pkg/kritis/client/clientset/versioned/typed/kritis/v1beta1/kritisconfig.go
+++ b/pkg/kritis/client/clientset/versioned/typed/kritis/v1beta1/kritisconfig.go
@@ -30,7 +30,7 @@ import (
 // KritisConfigsGetter has a method to return a KritisConfigInterface.
 // A group's client should implement this interface.
 type KritisConfigsGetter interface {
-	KritisConfigs(namespace string) KritisConfigInterface
+	KritisConfigs() KritisConfigInterface
 }
 
 // KritisConfigInterface has methods to work with KritisConfig resources.
@@ -49,14 +49,12 @@ type KritisConfigInterface interface {
 // kritisConfigs implements KritisConfigInterface
 type kritisConfigs struct {
 	client rest.Interface
-	ns     string
 }
 
 // newKritisConfigs returns a KritisConfigs
-func newKritisConfigs(c *KritisV1beta1Client, namespace string) *kritisConfigs {
+func newKritisConfigs(c *KritisV1beta1Client) *kritisConfigs {
 	return &kritisConfigs{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -64,7 +62,6 @@ func newKritisConfigs(c *KritisV1beta1Client, namespace string) *kritisConfigs {
 func (c *kritisConfigs) Get(name string, options v1.GetOptions) (result *v1beta1.KritisConfig, err error) {
 	result = &v1beta1.KritisConfig{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("kritisconfigs").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -77,7 +74,6 @@ func (c *kritisConfigs) Get(name string, options v1.GetOptions) (result *v1beta1
 func (c *kritisConfigs) List(opts v1.ListOptions) (result *v1beta1.KritisConfigList, err error) {
 	result = &v1beta1.KritisConfigList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("kritisconfigs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
@@ -89,7 +85,6 @@ func (c *kritisConfigs) List(opts v1.ListOptions) (result *v1beta1.KritisConfigL
 func (c *kritisConfigs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("kritisconfigs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Watch()
@@ -99,7 +94,6 @@ func (c *kritisConfigs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 func (c *kritisConfigs) Create(kritisConfig *v1beta1.KritisConfig) (result *v1beta1.KritisConfig, err error) {
 	result = &v1beta1.KritisConfig{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("kritisconfigs").
 		Body(kritisConfig).
 		Do().
@@ -111,7 +105,6 @@ func (c *kritisConfigs) Create(kritisConfig *v1beta1.KritisConfig) (result *v1be
 func (c *kritisConfigs) Update(kritisConfig *v1beta1.KritisConfig) (result *v1beta1.KritisConfig, err error) {
 	result = &v1beta1.KritisConfig{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("kritisconfigs").
 		Name(kritisConfig.Name).
 		Body(kritisConfig).
@@ -123,7 +116,6 @@ func (c *kritisConfigs) Update(kritisConfig *v1beta1.KritisConfig) (result *v1be
 // Delete takes name of the kritisConfig and deletes it. Returns an error if one occurs.
 func (c *kritisConfigs) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("kritisconfigs").
 		Name(name).
 		Body(options).
@@ -134,7 +126,6 @@ func (c *kritisConfigs) Delete(name string, options *v1.DeleteOptions) error {
 // DeleteCollection deletes a collection of objects.
 func (c *kritisConfigs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("kritisconfigs").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Body(options).
@@ -146,7 +137,6 @@ func (c *kritisConfigs) DeleteCollection(options *v1.DeleteOptions, listOptions 
 func (c *kritisConfigs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.KritisConfig, err error) {
 	result = &v1beta1.KritisConfig{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("kritisconfigs").
 		SubResource(subresources...).
 		Name(name).

--- a/pkg/kritis/client/listers/kritis/v1beta1/expansion_generated.go
+++ b/pkg/kritis/client/listers/kritis/v1beta1/expansion_generated.go
@@ -53,7 +53,3 @@ type ImageSecurityPolicyNamespaceListerExpansion interface{}
 // KritisConfigListerExpansion allows custom methods to be added to
 // KritisConfigLister.
 type KritisConfigListerExpansion interface{}
-
-// KritisConfigNamespaceListerExpansion allows custom methods to be added to
-// KritisConfigNamespaceLister.
-type KritisConfigNamespaceListerExpansion interface{}

--- a/pkg/kritis/client/listers/kritis/v1beta1/kritisconfig.go
+++ b/pkg/kritis/client/listers/kritis/v1beta1/kritisconfig.go
@@ -29,8 +29,8 @@ import (
 type KritisConfigLister interface {
 	// List lists all KritisConfigs in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.KritisConfig, err error)
-	// KritisConfigs returns an object that can list and get KritisConfigs.
-	KritisConfigs(namespace string) KritisConfigNamespaceLister
+	// Get retrieves the KritisConfig from the index for a given name.
+	Get(name string) (*v1beta1.KritisConfig, error)
 	KritisConfigListerExpansion
 }
 
@@ -52,38 +52,9 @@ func (s *kritisConfigLister) List(selector labels.Selector) (ret []*v1beta1.Krit
 	return ret, err
 }
 
-// KritisConfigs returns an object that can list and get KritisConfigs.
-func (s *kritisConfigLister) KritisConfigs(namespace string) KritisConfigNamespaceLister {
-	return kritisConfigNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// KritisConfigNamespaceLister helps list and get KritisConfigs.
-type KritisConfigNamespaceLister interface {
-	// List lists all KritisConfigs in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*v1beta1.KritisConfig, err error)
-	// Get retrieves the KritisConfig from the indexer for a given namespace and name.
-	Get(name string) (*v1beta1.KritisConfig, error)
-	KritisConfigNamespaceListerExpansion
-}
-
-// kritisConfigNamespaceLister implements the KritisConfigNamespaceLister
-// interface.
-type kritisConfigNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all KritisConfigs in the indexer for a given namespace.
-func (s kritisConfigNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.KritisConfig, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1beta1.KritisConfig))
-	})
-	return ret, err
-}
-
-// Get retrieves the KritisConfig from the indexer for a given namespace and name.
-func (s kritisConfigNamespaceLister) Get(name string) (*v1beta1.KritisConfig, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the KritisConfig from the index for a given name.
+func (s *kritisConfigLister) Get(name string) (*v1beta1.KritisConfig, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kritis/crd/kritisconfig/kritisconfig.go
+++ b/pkg/kritis/crd/kritisconfig/kritisconfig.go
@@ -25,9 +25,8 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// KritisConfigs returns all KritisConfigs in the specified namespace
-// Pass in an empty string to get all KritisConfigs in all namespaces
-func KritisConfigs(namespace string) ([]v1beta1.KritisConfig, error) {
+// KritisConfigs returns all KritisConfig in the cluster
+func KritisConfigs() ([]v1beta1.KritisConfig, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, fmt.Errorf("error building config: %v", err)
@@ -37,24 +36,9 @@ func KritisConfigs(namespace string) ([]v1beta1.KritisConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error building clientset: %v", err)
 	}
-	list, err := client.KritisV1beta1().KritisConfigs(namespace).List(metav1.ListOptions{})
+	list, err := client.KritisV1beta1().KritisConfigs().List(metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error listing all kritis configs: %v", err)
 	}
 	return list.Items, nil
-}
-
-// KritisConfig returns the KritisConfig in the specified namespace and with the given name
-// Returns error if KritisConfig is not found
-func KritisConfig(namespace string, name string) (*v1beta1.KritisConfig, error) {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, fmt.Errorf("error building config: %v", err)
-	}
-
-	client, err := clientset.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("error building clientset: %v", err)
-	}
-	return client.KritisV1beta1().KritisConfigs(namespace).Get(name, metav1.GetOptions{})
 }


### PR DESCRIPTION
1. Fixed retrieval of the cluster scoped `KritisConfig` CRD;
2. Fixed expected location of the certificates.