### PR TITLE
Fixed assumptions for KritisConfig's Grafeas address

### DIFF
--- a/pkg/kritis/metadata/grafeas/grafeas.go
+++ b/pkg/kritis/metadata/grafeas/grafeas.go
@@ -91,12 +91,8 @@ func New(config kritisv1beta1.GrafeasConfigSpec, certs *CertConfig) (*Client, er
 		if ok := certPool.AppendCertsFromPEM(ca); !ok {
 			return nil, fmt.Errorf("failed to append ca certs")
 		}
-		server, _, err := net.SplitHostPort(config.Addr)
-		if err != nil {
-			return nil, err
-		}
 		creds := credentials.NewTLS(&tls.Config{
-			ServerName:   server,
+			ServerName:   config.Addr,
 			Certificates: []tls.Certificate{certificate},
 			RootCAs:      certPool,
 		})


### PR DESCRIPTION
1. `ServerName` in `tls.Config` is now set to Grafeas address, which is the `kubectl svc` name;
2. Removed expectation that the Grafeas address is specified in the `host:port` format.