### PR TITLE
Added global allowlist logic to GenericAttestationPolicy

### DIFF
--- a/pkg/kritis/constants/constants.go
+++ b/pkg/kritis/constants/constants.go
@@ -60,5 +60,6 @@ var (
 		"gcr.io/kritis-project/preinstall",
 		"gcr.io/kritis-project/postinstall",
 		"gcr.io/kritis-project/predelete",
-		"us.gcr.io/grafeas/grafeas-server"}
+		"us.gcr.io/grafeas/grafeas-server",
+	}
 )

--- a/pkg/kritis/review/review.go
+++ b/pkg/kritis/review/review.go
@@ -57,6 +57,12 @@ func New(client metadata.Fetcher, c *Config) Reviewer {
 // ReviewGAP reviews images against generic attestation policies
 // Returns error if violations are found and handles them per violation strategy
 func (r Reviewer) ReviewGAP(images []string, gaps []v1beta1.GenericAttestationPolicy, pod *v1.Pod) error {
+	images = util.RemoveGloballyAllowedImages(images)
+	if len(images) == 0 {
+		glog.Infof("images are all globally allowed, returning successful status: %s", images)
+		return nil
+	}
+
 	if len(gaps) == 0 {
 		glog.Info("No Generic Attestation Policies found")
 		return nil

--- a/pkg/kritis/review/review_test.go
+++ b/pkg/kritis/review/review_test.go
@@ -211,6 +211,14 @@ func TestReviewGAP(t *testing.T) {
 			isAttested:   true,
 			shouldErr:    false,
 		},
+		{
+			name:         "image in global allowlist",
+			image:        "us.gcr.io/grafeas/grafeas-server:0.1.0",
+			policies:     twoGaps,
+			attestations: []metadata.PGPAttestation{},
+			isAttested:   false,
+			shouldErr:    false,
+		},
 	}
 	for _, tc := range tests {
 		th := violation.MemoryStrategy{


### PR DESCRIPTION
This enables for Grafeas server restarts when Kritis is already deployed and GenericAttestationPolicy is set.