### PR TITLE
Add pprof profiling to allow us to debug memory issues.

### DIFF
--- a/cmd/kritis/admission/main.go
+++ b/cmd/kritis/admission/main.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 	"time"
 
 	"github.com/golang/glog"


### PR DESCRIPTION
This should allow us to investigate bugs like #391 by requesting a dump of memory allocations