### PR TITLE
[Issue-391] - Fixes memory leak issue by closing unused connections

### DIFF
--- a/pkg/kritis/admission/admission.go
+++ b/pkg/kritis/admission/admission.go
@@ -244,6 +244,8 @@ func reviewImages(images []string, ns string, pod *v1.Pod, ar *v1beta1.Admission
 	// NOTE: pod may be nil if we are reviewing images for a replica set.
 	glog.Infof("Reviewing images for %s in namespace %s: %s", pod, ns, images)
 	client, err := admissionConfig.fetchMetadataClient(config)
+	defer client.Close()
+
 	if err != nil {
 		errMsg := fmt.Sprintf("error getting metadata client: %v", err)
 		glog.Errorf(errMsg)

--- a/pkg/kritis/metadata/containeranalysis/cache.go
+++ b/pkg/kritis/metadata/containeranalysis/cache.go
@@ -45,6 +45,11 @@ func NewCache() (*Cache, error) {
 	}, nil
 }
 
+// Close closes client connections
+func (c Cache) Close() {
+	c.client.Close()
+}
+
 // Vulnerabilities gets Package Vulnerabilities Occurrences for a specified image.
 func (c Cache) Vulnerabilities(image string) ([]metadata.Vulnerability, error) {
 	if v, ok := c.vuln[image]; ok {

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis.go
@@ -58,6 +58,11 @@ func New() (*Client, error) {
 	}, nil
 }
 
+// Close closes client connections
+func (c Client) Close() {
+	c.client.Close()
+}
+
 //Vulnerabilities gets Package Vulnerabilities Occurrences for a specified image.
 func (c Client) Vulnerabilities(containerImage string) ([]metadata.Vulnerability, error) {
 	occs, err := c.fetchOccurrence(containerImage, PkgVulnerability)

--- a/pkg/kritis/metadata/grafeas/grafeas.go
+++ b/pkg/kritis/metadata/grafeas/grafeas.go
@@ -111,6 +111,12 @@ func New(config kritisv1beta1.GrafeasConfigSpec, certs *CertConfig) (*Client, er
 	}, nil
 }
 
+// Close closes client connections
+func (c Client) Close() {
+	// Not Implemented.
+	// grafeas.GrafeasV1Beta1Client does not expose Close() method for conn.
+}
+
 // Vulnerabilities gets Package Vulnerabilities Occurrences for a specified image.
 func (c Client) Vulnerabilities(containerImage string) ([]metadata.Vulnerability, error) {
 	occs, err := c.fetchOccurrence(containerImage, PkgVulnerability)

--- a/pkg/kritis/metadata/metadata.go
+++ b/pkg/kritis/metadata/metadata.go
@@ -35,6 +35,8 @@ type Fetcher interface {
 	CreateAttestationNote(aa *kritisv1beta1.AttestationAuthority) (*grafeasv1beta1.Note, error)
 	//Attestations get Attestation Occurrences for given image.
 	Attestations(containerImage string) ([]PGPAttestation, error)
+	// Close closes client connections
+	Close()
 }
 
 type Vulnerability struct {

--- a/pkg/kritis/testutil/metadata_mock.go
+++ b/pkg/kritis/testutil/metadata_mock.go
@@ -31,6 +31,11 @@ type MockMetadataClient struct {
 	Occ             map[string]string
 }
 
+// Close does not do anything for MockMetadataClient
+func (m *MockMetadataClient) Close() {
+	// No ops
+}
+
 func (m *MockMetadataClient) Vulnerabilities(containerImage string) ([]metadata.Vulnerability, error) {
 	return m.Vulnz, nil
 }


### PR DESCRIPTION
Fixes Issue https://github.com/grafeas/kritis/issues/391

NOTE: This is not a clean solution. Ideally, Kritis should not create upstream client inside handler. It should be created outside and passed as an argument to request handlers. This way same client can be used by all goroutines. This will require a bit of refactoring, till then we can use this solution to fix memory issues. 