### PR TITLE
Improve unit test out readability with gotestsum.

### DIFF
--- a/hack/test.sh
+++ b/hack/test.sh
@@ -19,16 +19,18 @@ if [ ! -x "$(command -v gotestsum)" ] && [ ! -x $GOPATH/bin/gotestsum ]; then
     go get -u gotest.tools/gotestsum
 fi
 
-set -x
+set -ex
+
+pkgs2test=`go list ./...  | grep -v vendor`
 
 echo "Running go tests..."
 if [ -x "$(command -v gotestsum)" ]; then
-    timeout 60 gotestsum --format short-verbose
+    gotestsum -- -cover -timeout 60s $pkgs2test
 elif [ -x $GOPATH/bin/gotestsum ]; then
-    timeout 60 $GOPATH/bin/gotestsum --format short-verbose
+    $GOPATH/bin/gotestsum -- -cover -timeout 60s $pkgs2test
 else
     echo "gotestsum not installed, defaulting to regular test output."
-    go test -cover -v -timeout 60s `go list ./...  | grep -v vendor`
+    go test -cover -v -timeout 60s $pkgs2test
 fi
 
 GO_TEST_EXIT_CODE=${PIPESTATUS[0]}

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -19,7 +19,7 @@ if [ ! -x "$(command -v gotestsum)" ] && [ ! -x $GOPATH/bin/gotestsum ]; then
     go get -u gotest.tools/gotestsum
 fi
 
-set -ex
+set -e
 
 pkgs2test=`go list ./...  | grep -v vendor`
 

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -19,11 +19,7 @@ if [ ! -x "$(command -v gotestsum)" ] && [ ! -x $GOPATH/bin/gotestsum ]; then
     go get -u gotest.tools/gotestsum
 fi
 
-set -ex
-
-echo $GO111MODULE
-
-GO111MODULE=on
+set -x
 
 echo "Running go tests..."
 if [ -x "$(command -v gotestsum)" ]; then

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -23,9 +23,9 @@ set -ex
 
 echo "Running go tests..."
 if [ -x "$(command -v gotestsum)" ]; then
-    timeout 60 gotestsum
+    timeout 60 gotestsum --format short-verbose
 elif [ -x $GOPATH/bin/gotestsum ]; then
-    timeout 60 $GOPATH/bin/gotestsum
+    timeout 60 $GOPATH/bin/gotestsum --format short-verbose
 else
     echo "gotestsum not installed, defaulting to regular test output."
     go test -cover -v -timeout 60s `go list ./...  | grep -v vendor`

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -14,9 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if [ ! -x "$(command -v gotestsum)" ] && [ ! -x $GOPATH/bin/gotestsum ]; then
+    echo "gotestsum not found, try installing it..."
+    go get -u gotest.tools/gotestsum
+fi
+
 set -ex
 
 echo "Running go tests..."
-go test -cover -v -timeout 60s `go list ./...  | grep -v vendor`
+if [ -x "$(command -v gotestsum)" ]; then
+    timeout 60 gotestsum
+elif [ -x $GOPATH/bin/gotestsum ]; then
+    timeout 60 $GOPATH/bin/gotestsum
+else
+    echo "gotestsum not installed, defaulting to regular test output."
+    go test -cover -v -timeout 60s `go list ./...  | grep -v vendor`
+fi
+
 GO_TEST_EXIT_CODE=${PIPESTATUS[0]}
 exit $GO_TEST_EXIT_CODE

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -21,6 +21,10 @@ fi
 
 set -ex
 
+echo $GO111MODULE
+
+GO111MODULE=on
+
 echo "Running go tests..."
 if [ -x "$(command -v gotestsum)" ]; then
     timeout 60 gotestsum --format short-verbose


### PR DESCRIPTION
This PR will improve the readability of hack/test.sh out by using [gotestsum](https://github.com/gotestyourself/gotestsum). See `gotestsum` demo [here](https://raw.githubusercontent.com/gotestyourself/gotestsum/master/docs/demo.gif).

The updated hack/test.sh will try to install gotestsum if not yet there, and still defaults to regular go test even if installation fails.