### PR TITLE
Change AAList to single AA in ISP.

### DIFF
--- a/artifacts/examples/generic-attestation-policy-example.yaml
+++ b/artifacts/examples/generic-attestation-policy-example.yaml
@@ -4,5 +4,4 @@ metadata:
   name: my-gap
   namespace: default
 spec:
-  attestationAuthorityNames:
-  - kritis-authority
+  attestationAuthorityName: kritis-authority

--- a/artifacts/examples/image-security-policy-example.yaml
+++ b/artifacts/examples/image-security-policy-example.yaml
@@ -4,8 +4,7 @@ metadata:
   name: my-isp
   namespace: default
 spec:
-  attestationAuthorityNames:
-  - kritis-authority
+  attestationAuthorityName: kritis-authority
   imageAllowlist:
   - gcr.io/my/image
   packageVulnerabilityRequirements:

--- a/pkg/kritis/apis/kritis/v1beta1/securitypolicy.go
+++ b/pkg/kritis/apis/kritis/v1beta1/securitypolicy.go
@@ -35,7 +35,7 @@ type ImageSecurityPolicy struct {
 type ImageSecurityPolicySpec struct {
 	ImageAllowlist                   []string                         `json:"imageAllowlist"`
 	PackageVulnerabilityRequirements PackageVulnerabilityRequirements `json:"packageVulnerabilityRequirements"`
-	AttestationAuthorityNames        []string                         `json:"attestationAuthorityNames"`
+	AttestationAuthorityName         string                           `json:"attestationAuthorityName"`
 }
 
 // PackageVulnerabilityRequirements is the requirements for package vulnz for an ImageSecurityPolicy

--- a/pkg/kritis/apis/kritis/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/kritis/apis/kritis/v1beta1/zz_generated.deepcopy.go
@@ -359,11 +359,6 @@ func (in *ImageSecurityPolicySpec) DeepCopyInto(out *ImageSecurityPolicySpec) {
 		copy(*out, *in)
 	}
 	in.PackageVulnerabilityRequirements.DeepCopyInto(&out.PackageVulnerabilityRequirements)
-	if in.AttestationAuthorityNames != nil {
-		in, out := &in.AttestationAuthorityNames, &out.AttestationAuthorityNames
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 

--- a/pkg/kritis/review/review_test.go
+++ b/pkg/kritis/review/review_test.go
@@ -192,7 +192,7 @@ func TestReviewISP(t *testing.T) {
 				Namespace: "foo",
 			},
 			Spec: v1beta1.ImageSecurityPolicySpec{
-				AttestationAuthorityNames: []string{"test"},
+				AttestationAuthorityName: "test",
 			},
 		},
 	}
@@ -484,27 +484,28 @@ func TestGetAttestationAuthoritiesForISP(t *testing.T) {
 		Auths: authMock,
 	})
 	tcs := []struct {
-		name        string
-		aList       []string
-		shouldErr   bool
-		expectedLen int
+		name      string
+		aName     string
+		shouldErr bool
+		returnNil bool
 	}{
 		{
-			name:        "correct authorities list",
-			aList:       []string{"a1", "a2"},
-			shouldErr:   false,
-			expectedLen: 2,
+			name:      "correct authority",
+			aName:     "a1",
+			shouldErr: false,
+			returnNil: false,
 		},
 		{
-			name:      "one incorrect authority in the list",
-			aList:     []string{"a1", "err"},
+			name:      "incorrect authority",
+			aName:     "err",
 			shouldErr: true,
+			returnNil: true,
 		},
 		{
-			name:        "empty list should return nothing",
-			aList:       []string{},
-			shouldErr:   false,
-			expectedLen: 0,
+			name:      "empty name should return nil",
+			aName:     "",
+			shouldErr: false,
+			returnNil: true,
 		},
 	}
 
@@ -512,15 +513,15 @@ func TestGetAttestationAuthoritiesForISP(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			isp := v1beta1.ImageSecurityPolicy{
 				Spec: v1beta1.ImageSecurityPolicySpec{
-					AttestationAuthorityNames: tc.aList,
+					AttestationAuthorityName: tc.aName,
 				},
 			}
-			auths, err := r.getAttestationAuthoritiesForISP(isp)
+			a, err := r.getAttestationAuthorityForISP(isp)
 			if (err != nil) != tc.shouldErr {
 				t.Errorf("expected review to return error %t, actual error %s", tc.shouldErr, err)
 			}
-			if len(auths) != tc.expectedLen {
-				t.Errorf("expected review to return error %t, actual error %s", tc.shouldErr, err)
+			if (a == nil) != tc.returnNil {
+				t.Errorf("expected review to return nil %t, actual return nil %t", tc.returnNil, a == nil)
 			}
 		})
 	}


### PR DESCRIPTION
Attestation authority in ISP is used for signing image that passes vuln criteria. There is no need to have multiple AAs in ISP.
This change is also a prerequisite for moving secret key from AA to ISP.