### PR TITLE
Change AAList to single AA in ISP.

### DIFF
--- a/artifacts/examples/generic-attestation-policy-example.yaml
+++ b/artifacts/examples/generic-attestation-policy-example.yaml
@@ -4,5 +4,4 @@ metadata:
   name: my-gap
   namespace: default
 spec:
-  attestationAuthorityNames:
-  - kritis-authority
+  attestationAuthorityName: kritis-authority

--- a/artifacts/examples/generic-attestation-policy-example.yaml
+++ b/artifacts/examples/generic-attestation-policy-example.yaml
@@ -4,4 +4,5 @@ metadata:
   name: my-gap
   namespace: default
 spec:
-  attestationAuthorityName: kritis-authority
+  attestationAuthorityNames:
+  - kritis-authority

--- a/artifacts/examples/image-security-policy-example.yaml
+++ b/artifacts/examples/image-security-policy-example.yaml
@@ -4,8 +4,7 @@ metadata:
   name: my-isp
   namespace: default
 spec:
-  attestationAuthorityNames:
-  - kritis-authority
+  attestationAuthorityName: kritis-authority
   imageAllowlist:
   - gcr.io/my/image
   packageVulnerabilityRequirements:

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -47,6 +47,7 @@ metadata:
     name: my-isp
     namespace: example-namespace
 spec:
+  attestationAuthorityName: kritis-authority
   imageAllowlist:
   - gcr.io/my-project/allowlist-image@sha256:<DIGEST>
   packageVulnerabilityPolicy:
@@ -87,6 +88,7 @@ Image Security Policy Spec description:
 | Field     | Default (if applicable)   | Description |
 |-----------|---------------------------|-------------|
 |imageAllowlist | | List of images that are allowlisted and are not inspected by Admission Controller.|
+|attestationAuthorityName | | Attestation authority name for adding attestation.|
 |packageVulnerabilityPolicy.allowlistCVEs |  | List of CVEs which will be ignored.|
 |packageVulnerabilityPolicy.maximumSeverity| ALLOW_ALL | Tolerance level for vulnerabilities found in the container image.|
 |packageVulnerabilityPolicy.maximumFixUnavailableSeverity |  ALLOW_ALL | The tolerance level for vulnerabilities found that have no fix available.|
@@ -105,6 +107,12 @@ Here are the valid values for Policy Specs.
 |                                           | HIGH  | Allow Containers with Low, Medium & High  unpatchaable vulnerabilities. |
 |                                           | ALLOW_ALL | Allow all unpatchable vulnerabilities.  |
 |                                           | BLOCK_ALL | Block all unpatchable vulnerabilities except listed in allowlist. |
+
+### Image Security Policy Behavior
+An Image Security Policy will evaluate an image based on vulnerability policy specified in `packageVulnerabilityPolicy`.
+
+If the `attestationAuthorityName` field is specified in ISP with a non-empty value, ISP decision based on `packageVulnerabilityPolicy`
+will create an attestation for the specified attestation authority. The attestation will serve as a cache for fast decision next time.
 
 ## AttestationAuthority CRD
 

--- a/pkg/kritis/apis/kritis/v1beta1/securitypolicy.go
+++ b/pkg/kritis/apis/kritis/v1beta1/securitypolicy.go
@@ -35,7 +35,7 @@ type ImageSecurityPolicy struct {
 type ImageSecurityPolicySpec struct {
 	ImageAllowlist                   []string                         `json:"imageAllowlist"`
 	PackageVulnerabilityRequirements PackageVulnerabilityRequirements `json:"packageVulnerabilityRequirements"`
-	AttestationAuthorityNames        []string                         `json:"attestationAuthorityNames"`
+	AttestationAuthorityName         string                           `json:"attestationAuthorityName"`
 }
 
 // PackageVulnerabilityRequirements is the requirements for package vulnz for an ImageSecurityPolicy

--- a/pkg/kritis/apis/kritis/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/kritis/apis/kritis/v1beta1/zz_generated.deepcopy.go
@@ -359,11 +359,6 @@ func (in *ImageSecurityPolicySpec) DeepCopyInto(out *ImageSecurityPolicySpec) {
 		copy(*out, *in)
 	}
 	in.PackageVulnerabilityRequirements.DeepCopyInto(&out.PackageVulnerabilityRequirements)
-	if in.AttestationAuthorityNames != nil {
-		in, out := &in.AttestationAuthorityNames, &out.AttestationAuthorityNames
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 

--- a/pkg/kritis/review/review.go
+++ b/pkg/kritis/review/review.go
@@ -134,7 +134,7 @@ func (r Reviewer) ReviewISP(images []string, isps []v1beta1.ImageSecurityPolicy,
 				return r.handleViolations(image, pod, violations)
 			}
 			if r.config.IsWebhook && auth != nil {
-				if err := r.addAttestations(image, isp, *auth); err != nil {
+				if err := r.addAttestation(image, isp, *auth); err != nil {
 					glog.Errorf("error adding attestations %s", err)
 				}
 			}
@@ -186,7 +186,7 @@ func (r Reviewer) handleViolations(image string, pod *v1.Pod, violations []polic
 }
 
 // Create attestation for 'image' by ISP auth.
-func (r Reviewer) addAttestations(image string, isp v1beta1.ImageSecurityPolicy, auth v1beta1.AttestationAuthority) error {
+func (r Reviewer) addAttestation(image string, isp v1beta1.ImageSecurityPolicy, auth v1beta1.AttestationAuthority) error {
 	errMsgs := []string{}
 	// Get or Create Note for this this Authority
 	n, err := util.GetOrCreateAttestationNote(r.client, &auth)

--- a/pkg/kritis/review/review.go
+++ b/pkg/kritis/review/review.go
@@ -103,19 +103,18 @@ func (r Reviewer) ReviewISP(images []string, isps []v1beta1.ImageSecurityPolicy,
 
 	for _, isp := range isps {
 		glog.Infof("Validating against ImageSecurityPolicy %s", isp.Name)
-		// Get all AttestationAuthorities in this policy.
-		a, err := r.getAttestationAuthorityForISP(isp)
+		// Get the attestationauthority in this policy.
+		auth, err := r.getAttestationAuthorityForISP(isp)
 		if err != nil {
 			return err
 		}
-		auths := make([]v1beta1.AttestationAuthority, 0)
-		if a != nil {
-			auths = append(auths, *a)
-		}
+
 		for _, image := range images {
 			glog.Infof("Check if %s as valid Attestations.", image)
-			notAttestedBy := r.findUnsatisfiedAuths(image, auths)
-			imgAttested := len(notAttestedBy) == 0
+			imgAttested := false
+			if auth != nil {
+				imgAttested = r.isAttestedBy(image, *auth)
+			}
 
 			if err := r.config.Strategy.HandleAttestation(image, pod, imgAttested); err != nil {
 				glog.Errorf("error handling attestations %v", err)
@@ -134,8 +133,8 @@ func (r Reviewer) ReviewISP(images []string, isps []v1beta1.ImageSecurityPolicy,
 			if len(violations) != 0 {
 				return r.handleViolations(image, pod, violations)
 			}
-			if r.config.IsWebhook {
-				if err := r.addAttestations(image, isp, notAttestedBy); err != nil {
+			if r.config.IsWebhook && auth != nil {
+				if err := r.addAttestations(image, isp, *auth); err != nil {
 					glog.Errorf("error adding attestations %s", err)
 				}
 			}
@@ -145,17 +144,25 @@ func (r Reviewer) ReviewISP(images []string, isps []v1beta1.ImageSecurityPolicy,
 	return nil
 }
 
+// Check if a image is attested by a given attestation authority.
+func (r Reviewer) isAttestedBy(image string, auth v1beta1.AttestationAuthority) bool {
+	transport := AttestorValidatingTransport{Client: r.client, Attestor: auth}
+	attestations, err := transport.GetValidatedAttestations(image)
+	if err != nil {
+		glog.Errorf("Error fetching validated attestations for %s: %v", image, err)
+	}
+	if len(attestations) == 0 {
+		return false
+	}
+	return true
+}
+
 // Returns a subset of 'auths' for which there are no attestations for 'image'.
 // In particular, if this returns an empty result, then 'image' has at least one attestation by every AttestationAuthority from 'auths'.
 func (r Reviewer) findUnsatisfiedAuths(image string, auths []v1beta1.AttestationAuthority) []v1beta1.AttestationAuthority {
 	notAttestedBy := []v1beta1.AttestationAuthority{}
 	for _, auth := range auths {
-		transport := AttestorValidatingTransport{Client: r.client, Attestor: auth}
-		attestations, err := transport.GetValidatedAttestations(image)
-		if err != nil {
-			glog.Errorf("Error fetching validated attestations for %s: %v", image, err)
-		}
-		if len(attestations) == 0 {
+		if !r.isAttestedBy(image, auth) {
 			notAttestedBy = append(notAttestedBy, auth)
 		}
 	}
@@ -178,26 +185,24 @@ func (r Reviewer) handleViolations(image string, pod *v1.Pod, violations []polic
 	return fmt.Errorf(errMsg)
 }
 
-// Create attestations for 'image' by all 'auths'.
-func (r Reviewer) addAttestations(image string, isp v1beta1.ImageSecurityPolicy, auths []v1beta1.AttestationAuthority) error {
+// Create attestation for 'image' by ISP auth.
+func (r Reviewer) addAttestations(image string, isp v1beta1.ImageSecurityPolicy, auth v1beta1.AttestationAuthority) error {
 	errMsgs := []string{}
-	for _, a := range auths {
-		// Get or Create Note for this this Authority
-		n, err := util.GetOrCreateAttestationNote(r.client, &a)
-		if err != nil {
-			errMsgs = append(errMsgs, err.Error())
-		}
-		// Get secret for this Authority
-		s, err := r.config.Secret(isp.Namespace, a.Spec.PrivateKeySecretName)
-		if err != nil {
-			errMsgs = append(errMsgs, err.Error())
-		}
-		// Create Attestation Signature
-		if _, err := r.client.CreateAttestationOccurence(n, image, s); err != nil {
-			errMsgs = append(errMsgs, err.Error())
-		}
-
+	// Get or Create Note for this this Authority
+	n, err := util.GetOrCreateAttestationNote(r.client, &auth)
+	if err != nil {
+		errMsgs = append(errMsgs, err.Error())
 	}
+	// Get secret for this Authority
+	s, err := r.config.Secret(isp.Namespace, auth.Spec.PrivateKeySecretName)
+	if err != nil {
+		errMsgs = append(errMsgs, err.Error())
+	}
+	// Create Attestation Signature
+	if _, err := r.client.CreateAttestationOccurence(n, image, s); err != nil {
+		errMsgs = append(errMsgs, err.Error())
+	}
+
 	if len(errMsgs) == 0 {
 		return nil
 	}

--- a/pkg/kritis/review/review_test.go
+++ b/pkg/kritis/review/review_test.go
@@ -192,7 +192,7 @@ func TestReviewISP(t *testing.T) {
 				Namespace: "foo",
 			},
 			Spec: v1beta1.ImageSecurityPolicySpec{
-				AttestationAuthorityNames: []string{"test"},
+				AttestationAuthorityName: "test",
 			},
 		},
 	}
@@ -484,27 +484,28 @@ func TestGetAttestationAuthoritiesForISP(t *testing.T) {
 		Auths: authMock,
 	})
 	tcs := []struct {
-		name        string
-		aList       []string
-		shouldErr   bool
-		expectedLen int
+		name      string
+		aName     string
+		shouldErr bool
+		returnNil bool
 	}{
 		{
-			name:        "correct authorities list",
-			aList:       []string{"a1", "a2"},
-			shouldErr:   false,
-			expectedLen: 2,
+			name:      "correct authority",
+			aName:     "a1",
+			shouldErr: false,
+			returnNil: false,
 		},
 		{
-			name:      "one incorrect authority in the list",
-			aList:     []string{"a1", "err"},
+			name:      "incorrect authority",
+			aName:     "err",
 			shouldErr: true,
+			returnNil: true,
 		},
 		{
-			name:        "empty list should return nothing",
-			aList:       []string{},
-			shouldErr:   false,
-			expectedLen: 0,
+			name:      "empty name should return nil",
+			aName:     "",
+			shouldErr: false,
+			returnNil: true,
 		},
 	}
 
@@ -512,15 +513,15 @@ func TestGetAttestationAuthoritiesForISP(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			isp := v1beta1.ImageSecurityPolicy{
 				Spec: v1beta1.ImageSecurityPolicySpec{
-					AttestationAuthorityNames: tc.aList,
+					AttestationAuthorityName: tc.aName,
 				},
 			}
-			auths, err := r.getAttestationAuthoritiesForISP(isp)
+			a, err := r.getAttestationAuthorityForISP(isp)
 			if (err != nil) != tc.shouldErr {
 				t.Errorf("expected review to return error %t, actual error %s", tc.shouldErr, err)
 			}
-			if len(auths) != tc.expectedLen {
-				t.Errorf("expected review to return error %t, actual error %s", tc.shouldErr, err)
+			if (a == nil) != tc.returnNil {
+				t.Errorf("expected review to return nil %t, actual return nil %t", tc.returnNil, a == nil)
 			}
 		})
 	}


### PR DESCRIPTION
Attestation authority in ISP is used for signing image that passes vuln criteria. There is no need to have multiple AAs in ISP.
This change is also a prerequisite for moving secret key from AA to ISP.

This PR is part of bundled change to achieve better compatibility with Binary Authorization.