### PR TITLE
Fix a logic bug in the GenericAttestationPolicy review.

### DIFF
--- a/pkg/kritis/review/review.go
+++ b/pkg/kritis/review/review.go
@@ -68,7 +68,7 @@ func (r Reviewer) ReviewGAP(images []string, gaps []v1beta1.GenericAttestationPo
 
 	for _, image := range images {
 		glog.Infof("Check if %s has valid Attestations.", image)
-		var imgAttested bool
+		imgAttested := false
 		for _, gap := range gaps {
 			glog.Infof("Validating against GenericAttestationPolicy %s", gap.Name)
 			// Get all AttestationAuthorities in this policy.
@@ -76,8 +76,10 @@ func (r Reviewer) ReviewGAP(images []string, gaps []v1beta1.GenericAttestationPo
 			if err != nil {
 				return err
 			}
-			notAttestedBy := r.findUnsatisfiedAuths(image, auths)
-			imgAttested = len(notAttestedBy) == 0
+			_, attestedByAny := r.findUnsatisfiedAuths(image, auths)
+			if attestedByAny {
+				imgAttested = true
+			}
 		}
 		if err := r.config.Strategy.HandleAttestation(image, pod, imgAttested); err != nil {
 			glog.Errorf("error handling attestations %v", err)
@@ -110,8 +112,7 @@ func (r Reviewer) ReviewISP(images []string, isps []v1beta1.ImageSecurityPolicy,
 		}
 		for _, image := range images {
 			glog.Infof("Check if %s as valid Attestations.", image)
-			notAttestedBy := r.findUnsatisfiedAuths(image, auths)
-			imgAttested := len(notAttestedBy) == 0
+			notAttestedBy, imgAttested := r.findUnsatisfiedAuths(image, auths)
 
 			if err := r.config.Strategy.HandleAttestation(image, pod, imgAttested); err != nil {
 				glog.Errorf("error handling attestations %v", err)
@@ -141,10 +142,10 @@ func (r Reviewer) ReviewISP(images []string, isps []v1beta1.ImageSecurityPolicy,
 	return nil
 }
 
-// Returns a subset of 'auths' for which there are no attestations for 'image'.
-// In particular, if this returns an empty result, then 'image' has at least one attestation by every AttestationAuthority from 'auths'.
-func (r Reviewer) findUnsatisfiedAuths(image string, auths []v1beta1.AttestationAuthority) []v1beta1.AttestationAuthority {
+// Returns a subset of 'auths' for which there are no attestations for 'image', as well as an indicator if any auth satisfies image.
+func (r Reviewer) findUnsatisfiedAuths(image string, auths []v1beta1.AttestationAuthority) ([]v1beta1.AttestationAuthority, bool) {
 	notAttestedBy := []v1beta1.AttestationAuthority{}
+	attestedByAny := false
 	for _, auth := range auths {
 		transport := AttestorValidatingTransport{Client: r.client, Attestor: auth}
 		attestations, err := transport.GetValidatedAttestations(image)
@@ -153,9 +154,11 @@ func (r Reviewer) findUnsatisfiedAuths(image string, auths []v1beta1.Attestation
 		}
 		if len(attestations) == 0 {
 			notAttestedBy = append(notAttestedBy, auth)
+		} else {
+			attestedByAny = true
 		}
 	}
-	return notAttestedBy
+	return notAttestedBy, attestedByAny
 }
 
 func (r Reviewer) handleViolations(image string, pod *v1.Pod, violations []policy.Violation) error {

--- a/pkg/kritis/review/review_test.go
+++ b/pkg/kritis/review/review_test.go
@@ -84,8 +84,10 @@ func TestReviewGAP(t *testing.T) {
 			},
 		},
 	}
-	// One policy with two attestors: 'test', 'test2'.
-	GAPWithTwoAAs := []v1beta1.GenericAttestationPolicy{{
+	// One policy with two attestors:
+	// 'test' -- satisfies QualifiedImage
+	// 'test2' -- does not satisfy any image in this test
+	gapWithTwoAAs := []v1beta1.GenericAttestationPolicy{{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
 		},
@@ -179,7 +181,7 @@ func TestReviewGAP(t *testing.T) {
 		{
 			name:         "image attested by one attestor out of two",
 			image:        img,
-			policies:     GAPWithTwoAAs,
+			policies:     gapWithTwoAAs,
 			attestations: validAtts,
 			isAttested:   true,
 			shouldErr:    false,


### PR DESCRIPTION
Currently intended semantics is disjunctive: an image passes policy
checks if at least one GAP is satisfied, which in turn is if at least
one AttestationAuthority verifies the signature.