### PR TITLE
Fixed integration to use NoteReference in AttestationAuthority for attaching occurrences

### DIFF
--- a/artifacts/examples/attestation-authority-example.yaml
+++ b/artifacts/examples/attestation-authority-example.yaml
@@ -4,5 +4,5 @@ metadata:
   name: kritis-authority
   namespace: default
 spec:
-  noteReference: v1alpha1/projects/kritis-test1
+  noteReference: projects/kritis-test1
   privateKeySecretName: kritis-authority-key

--- a/docs/install.md
+++ b/docs/install.md
@@ -102,6 +102,10 @@ gcloud projects add-iam-policy-binding $PROJECT \
 gcloud projects add-iam-policy-binding $PROJECT \
   --member=serviceAccount:kritis-ca-admin@${PROJECT}.iam.gserviceaccount.com \
   --role=roles/containeranalysis.occurrences.editor
+
+gcloud projects add-iam-policy-binding $PROJECT \
+  --member=serviceAccount:kritis-ca-admin@${PROJECT}.iam.gserviceaccount.com \
+  --role=roles/containeranalysis.notes.occurrences.viewer
 ```
 
 ## Step #5: Upload the Service Account Key

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -139,7 +139,7 @@ metadata:
     name: qa-attestator
     namespace: qa
 spec:
-    noteReference: v1alpha1/projects/image-attestor
+    noteReference: projects/image-attestor
     privateKeySecretName: foo
     publicKeyData: ...
 ```

--- a/integration/crd.go
+++ b/integration/crd.go
@@ -37,7 +37,7 @@ kind: AttestationAuthority
 metadata:
   name: test-attestor
 spec:
-  noteReference: projects/krits-int-test
+  noteReference: projects/kritis-int-test
   privateKeySecretName: %s
   publicKeyData: %s`
 )

--- a/integration/crd.go
+++ b/integration/crd.go
@@ -37,7 +37,7 @@ kind: AttestationAuthority
 metadata:
   name: test-attestor
 spec:
-  noteReference: v1alpha1/projects/krits-int-test
+  noteReference: projects/krits-int-test
   privateKeySecretName: %s
   publicKeyData: %s`
 )

--- a/pkg/kritis/gcbsigner/signer.go
+++ b/pkg/kritis/gcbsigner/signer.go
@@ -89,6 +89,6 @@ func (s Signer) addAttestation(image string, ns string, authority string) error 
 		return err
 	}
 	// Create Attestation Signature
-	_, err = s.client.CreateAttestationOccurence(n, image, sec, grafeas.DefaultProject)
+	_, err = s.client.CreateAttestationOccurrence(n, image, sec, grafeas.DefaultProject)
 	return err
 }

--- a/pkg/kritis/metadata/containeranalysis/cache.go
+++ b/pkg/kritis/metadata/containeranalysis/cache.go
@@ -91,7 +91,7 @@ func (c Cache) AttestationNote(aa *kritisv1beta1.AttestationAuthority) (*grafeas
 	return n, err
 }
 
-// CreateAttestationOccurence creates an Attestation occurrence for a given image, secret, and project.
-func (c Cache) CreateAttestationOccurence(n *grafeas.Note, image string, p *secrets.PGPSigningSecret, proj string) (*grafeas.Occurrence, error) {
-	return c.client.CreateAttestationOccurence(n, image, p, proj)
+// CreateAttestationOccurrence creates an Attestation occurrence for a given image, secret, and project.
+func (c Cache) CreateAttestationOccurrence(n *grafeas.Note, image string, p *secrets.PGPSigningSecret, proj string) (*grafeas.Occurrence, error) {
+	return c.client.CreateAttestationOccurrence(n, image, p, proj)
 }

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis.go
@@ -128,8 +128,9 @@ func (c Client) fetchAttestationOccurrence(containerImage string, kind string, a
 		return nil, fmt.Errorf("%s is not a valid image hosted in GCR", containerImage)
 	}
 
+	noteName := fmt.Sprintf("%s/notes/%s", auth.Spec.NoteReference, auth.Name)
 	req := &grafeas.ListNoteOccurrencesRequest{
-		Name: auth.Spec.NoteReference,
+		Name: noteName,
 		// TODO: re-add `kind` clause in filter
 		//       (currently not supported as per https://github.com/grafeas/kritis/issues/401#issuecomment-538947608)
 		// Example:
@@ -173,17 +174,9 @@ func isRegistryGCR(r string) bool {
 	return true
 }
 
-func getProjectFromNoteReference(ref string) (string, error) {
-	str := strings.Split(ref, "/")
-	if len(str) < 3 {
-		return "", fmt.Errorf("invalid Note Reference. should be in format <api>/projects/<project_id>")
-	}
-	return str[2], nil
-}
-
 // CreateAttestationNote creates an attestation note from AttestationAuthority
 func (c Client) CreateAttestationNote(aa *kritisv1beta1.AttestationAuthority) (*grafeas.Note, error) {
-	noteProject, err := getProjectFromNoteReference(aa.Spec.NoteReference)
+	noteProject, err := metadata.GetProjectFromNoteReference(aa.Spec.NoteReference)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +204,7 @@ func (c Client) CreateAttestationNote(aa *kritisv1beta1.AttestationAuthority) (*
 
 //AttestationNote returns a note if it exists for given AttestationAuthority
 func (c Client) AttestationNote(aa *kritisv1beta1.AttestationAuthority) (*grafeas.Note, error) {
-	noteProject, err := getProjectFromNoteReference(aa.Spec.NoteReference)
+	noteProject, err := metadata.GetProjectFromNoteReference(aa.Spec.NoteReference)
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +270,7 @@ func getProjectFromContainerImage(image string) string {
 
 // DeleteAttestationNote deletes a note for given AttestationAuthority
 func (c Client) DeleteAttestationNote(aa *kritisv1beta1.AttestationAuthority) error {
-	noteProject, err := getProjectFromNoteReference(aa.Spec.NoteReference)
+	noteProject, err := metadata.GetProjectFromNoteReference(aa.Spec.NoteReference)
 	if err != nil {
 		return err
 	}

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	kritisv1beta1 "github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
+	"github.com/grafeas/kritis/pkg/kritis/metadata"
 	"github.com/grafeas/kritis/pkg/kritis/secrets"
 	"github.com/grafeas/kritis/pkg/kritis/testutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -95,7 +96,12 @@ func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
 		SecretName: "test",
 	}
 
-	occ, err := d.CreateAttestationOccurence(note, testutil.IntTestImage, secret, IntProject)
+	proj, err := metadata.GetProjectFromNoteReference(aa.Spec.NoteReference)
+	if err != nil {
+		t.Fatalf("Failed to extract project ID %v", err)
+	}
+	occ, err := d.CreateAttestationOccurrence(note, testutil.IntTestImage, secret, proj)
+	t.Logf("Occurrence=%v", occ)
 	if err != nil {
 		t.Fatalf("Unexpected error while creating Occurence %v", err)
 	}
@@ -113,6 +119,7 @@ func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error while listing Occ %v", err)
 	}
+	t.Logf("Occurrences=%v", occurrences)
 	if occurrences == nil {
 		t.Fatal("Should have created at least 1 occurrence")
 	}

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
@@ -30,14 +30,13 @@ import (
 
 var (
 	IntTestNoteName = "test-aa-note"
-	IntAPI          = "testv1"
 	IntProject      = "kritis-int-test"
 )
 
-func GetAA() []kritisv1beta1.AttestationAuthority {
+func GetAA() *kritisv1beta1.AttestationAuthority {
 	aa := &kritisv1beta1.AttestationAuthority{
 		Spec: kritisv1beta1.AttestationAuthoritySpec{
-			NoteReference: fmt.Sprintf("%s/projects/%s", IntAPI, IntProject),
+			NoteReference: fmt.Sprintf("projects/%s", IntProject),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: IntTestNoteName,

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
@@ -85,6 +85,7 @@ func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
 	if actualHint != IntTestNoteName {
 		t.Fatalf("Expected %s.\n Got %s", expectedNoteName, actualHint)
 	}
+
 	// Test Create Attestation Occurence
 	pub, priv := testutil.CreateKeyPair(t, "test")
 	pgpKey, err := secrets.NewPgpKey(priv, "", pub)
@@ -101,7 +102,6 @@ func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
 		t.Fatalf("Failed to extract project ID %v", err)
 	}
 	occ, err := d.CreateAttestationOccurrence(note, testutil.IntTestImage, secret, proj)
-	t.Logf("Occurrence=%v", occ)
 	if err != nil {
 		t.Fatalf("Unexpected error while creating Occurence %v", err)
 	}
@@ -119,7 +119,6 @@ func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error while listing Occ %v", err)
 	}
-	t.Logf("Occurrences=%v", occurrences)
 	if occurrences == nil {
 		t.Fatal("Should have created at least 1 occurrence")
 	}

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
@@ -131,7 +131,8 @@ func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
 			if occurrences, err := d.Attestations(testutil.IntTestImage, aa); err != nil {
 				t.Fatalf("Failed to retrieve attestations: %v", err)
 			} else if len(occurrences) > 0 {
-				break
+				// Successfully retrieved attestations, exit the loop and the test.
+				return
 			}
 		}
 	}

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_test.go
@@ -19,6 +19,7 @@ package containeranalysis
 import (
 	"testing"
 
+	"github.com/grafeas/kritis/pkg/kritis/metadata"
 	"github.com/grafeas/kritis/pkg/kritis/testutil"
 )
 
@@ -80,13 +81,13 @@ func TestGetProjectFromNoteRef(t *testing.T) {
 		shdErr bool
 		output string
 	}{
-		{"good", "v1aplha1/projects/name", false, "name"},
+		{"good", "projects/name", false, "name"},
 		{"bad1", "some", true, ""},
-		{"bad2", "some/t", true, ""},
+		{"bad2", "v1aplha1/projects/name", true, ""},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := getProjectFromNoteReference(tc.input)
+			actual, err := metadata.GetProjectFromNoteReference(tc.input)
 			testutil.CheckErrorAndDeepEqual(t, tc.shdErr, err, tc.output, actual)
 		})
 	}

--- a/pkg/kritis/metadata/grafeas/grafeas.go
+++ b/pkg/kritis/metadata/grafeas/grafeas.go
@@ -189,8 +189,8 @@ func (c Client) AttestationNote(aa *kritisv1beta1.AttestationAuthority) (*grafea
 	return c.client.GetNote(c.ctx, req)
 }
 
-// CreateAttestationOccurence creates an Attestation occurrence for a given image, secret, and project.
-func (c Client) CreateAttestationOccurence(note *grafeas.Note,
+// CreateAttestationOccurrence creates an Attestation occurrence for a given image, secret, and project.
+func (c Client) CreateAttestationOccurrence(note *grafeas.Note,
 	containerImage string,
 	pgpSigningKey *secrets.PGPSigningSecret, proj string) (*grafeas.Occurrence, error) {
 	fingerprint := util.GetAttestationKeyFingerprint(pgpSigningKey)

--- a/pkg/kritis/metadata/grafeas/grafeas.go
+++ b/pkg/kritis/metadata/grafeas/grafeas.go
@@ -149,7 +149,7 @@ func (c Client) Attestations(containerImage string, aa *kritisv1beta1.Attestatio
 
 // CreateAttestationNote creates an attestation note from AttestationAuthority
 func (c Client) CreateAttestationNote(aa *kritisv1beta1.AttestationAuthority) (*grafeas.Note, error) {
-	noteProject, err := getProjectFromNoteReference(aa.Spec.NoteReference)
+	noteProject, err := metadata.GetProjectFromNoteReference(aa.Spec.NoteReference)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func (c Client) CreateAttestationNote(aa *kritisv1beta1.AttestationAuthority) (*
 
 //AttestationNote returns a note if it exists for given AttestationAuthority
 func (c Client) AttestationNote(aa *kritisv1beta1.AttestationAuthority) (*grafeas.Note, error) {
-	noteProject, err := getProjectFromNoteReference(aa.Spec.NoteReference)
+	noteProject, err := metadata.GetProjectFromNoteReference(aa.Spec.NoteReference)
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +253,7 @@ func (c Client) fetchVulnerabilityOccurrence(containerImage string, kind string)
 }
 
 func (c Client) fetchAttestationOccurrence(containerImage string, kind string, aa *kritisv1beta1.AttestationAuthority) ([]*grafeas.Occurrence, error) {
-	noteProject, err := getProjectFromNoteReference(aa.Spec.NoteReference)
+	noteProject, err := metadata.GetProjectFromNoteReference(aa.Spec.NoteReference)
 	if err != nil {
 		return nil, err
 	}
@@ -278,12 +278,4 @@ func (c Client) fetchAttestationOccurrence(containerImage string, kind string, a
 		}
 	}
 	return occs, nil
-}
-
-func getProjectFromNoteReference(ref string) (string, error) {
-	str := strings.Split(ref, "/")
-	if len(str) < 3 {
-		return "", fmt.Errorf("invalid Note Reference. should be in format <api>/projects/<project_id>")
-	}
-	return str[2], nil
 }

--- a/pkg/kritis/metadata/grafeas/grafeas_test.go
+++ b/pkg/kritis/metadata/grafeas/grafeas_test.go
@@ -176,9 +176,9 @@ func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
 		PgpKey:     pgpKey,
 		SecretName: "test",
 	}
-	occ, err := client.CreateAttestationOccurence(note, testutil.IntTestImage, secret, DefaultProject)
+	occ, err := client.CreateAttestationOccurrence(note, testutil.IntTestImage, secret, DefaultProject)
 	if err != nil {
-		t.Fatalf("Unexpected error while creating Occurence %v", err)
+		t.Fatalf("Unexpected error while creating Occurrence %v", err)
 	}
 	expectedPgpKeyID := pgpKey.Fingerprint()
 	if err != nil {

--- a/pkg/kritis/metadata/grafeas/grafeas_test.go
+++ b/pkg/kritis/metadata/grafeas/grafeas_test.go
@@ -145,7 +145,7 @@ func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
 	}
 	aa := &kritisv1beta1.AttestationAuthority{
 		Spec: kritisv1beta1.AttestationAuthoritySpec{
-			NoteReference: fmt.Sprintf("%s/projects/%s", "api", DefaultProject),
+			NoteReference: fmt.Sprintf("projects/%s", DefaultProject),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "note1",

--- a/pkg/kritis/metadata/metadata.go
+++ b/pkg/kritis/metadata/metadata.go
@@ -28,8 +28,8 @@ import (
 type Fetcher interface {
 	// Vulnerabilities returns package vulnerabilities for a given image.
 	Vulnerabilities(containerImage string) ([]Vulnerability, error)
-	// CreateAttestationOccurence creates an Attestation occurrence for a given image, secret, and project.
-	CreateAttestationOccurence(note *grafeasv1beta1.Note,
+	// CreateAttestationOccurrence creates an Attestation occurrence for a given image, secret, and project.
+	CreateAttestationOccurrence(note *grafeasv1beta1.Note,
 		containerImage string, pgpSigningKey *secrets.PGPSigningSecret,
 		proj string) (*grafeasv1beta1.Occurrence, error)
 	//AttestationNote fetches an Attestation note for an Attestation Authority.

--- a/pkg/kritis/metadata/metadata.go
+++ b/pkg/kritis/metadata/metadata.go
@@ -17,6 +17,9 @@ limitations under the License.
 package metadata
 
 import (
+	"fmt"
+	"strings"
+
 	kritisv1beta1 "github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
 	"github.com/grafeas/kritis/pkg/kritis/secrets"
 	grafeasv1beta1 "google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1/grafeas"
@@ -52,4 +55,16 @@ type PGPAttestation struct {
 	KeyID     string
 	// OccID is the occurrence ID for containeranalysis Occurrence_Attestation instance
 	OccID string
+}
+
+// GetProjectFromNoteReference extracts the project ID form the NoteReference
+func GetProjectFromNoteReference(ref string) (string, error) {
+	str := strings.Split(ref, "/")
+	if len(str) != 2 {
+		return "", fmt.Errorf("invalid Note Reference, should be in format projects/<project_id>")
+	}
+	if str[0] != "projects" {
+		return "", fmt.Errorf("invalid Note Reference, should be in format projects/<project_id>")
+	}
+	return str[1], nil
 }

--- a/pkg/kritis/review/review.go
+++ b/pkg/kritis/review/review.go
@@ -192,7 +192,7 @@ func (r Reviewer) addAttestations(image string, isp v1beta1.ImageSecurityPolicy,
 			errMsgs = append(errMsgs, err.Error())
 		}
 		// Create Attestation Signature
-		if _, err := r.client.CreateAttestationOccurence(n, image, s, grafeas.DefaultProject); err != nil {
+		if _, err := r.client.CreateAttestationOccurrence(n, image, s, grafeas.DefaultProject); err != nil {
 			errMsgs = append(errMsgs, err.Error())
 		}
 

--- a/pkg/kritis/testutil/metadata_mock.go
+++ b/pkg/kritis/testutil/metadata_mock.go
@@ -49,7 +49,7 @@ func (m *MockMetadataClient) Vulnerabilities(containerImage string) ([]metadata.
 	return m.Vulnz, nil
 }
 
-func (m *MockMetadataClient) CreateAttestationOccurence(n *grafeas.Note, image string,
+func (m *MockMetadataClient) CreateAttestationOccurrence(n *grafeas.Note, image string,
 	s *secrets.PGPSigningSecret, proj string) (*grafeas.Occurrence, error) {
 	if m.Err != nil {
 		return nil, m.Err


### PR DESCRIPTION
This addresses integration issues that were uncovered when we moved to using `ListNoteOccurrences` in #399, and completes the implementation for #396.

* Removed API version from AttestationAuthority's `NoteReference`.
* Fixed note name in the `ListNoteOccurrencesRequest`.
* Fixed retrieval of note occurrences logic.
* s/Occurence/Occurrence
* moved `GetProjectFromNoteReference` to `metadata`, which is lowest common ancestor, to avoid code duplication