### PR TITLE
Define a read-only metadata client and use it in GAP

### DIFF
--- a/pkg/kritis/admission/admission.go
+++ b/pkg/kritis/admission/admission.go
@@ -47,7 +47,7 @@ import (
 type config struct {
 	retrievePod                     func(r *http.Request) (*v1.Pod, v1beta1.AdmissionReview, error)
 	retrieveDeployment              func(r *http.Request) (*appsv1.Deployment, v1beta1.AdmissionReview, error)
-	fetchMetadataClient             func(config *Config) (metadata.Fetcher, error)
+	fetchMetadataClient             func(config *Config) (metadata.ReadWriteClient, error)
 	fetchMetadataReadOnlyClient     func(config *Config) (metadata.ReadOnlyClient, error)
 	fetchGenericAttestationPolicies func(namespace string) ([]kritis.GenericAttestationPolicy, error)
 	fetchImageSecurityPolicies      func(namespace string) ([]kritis.ImageSecurityPolicy, error)
@@ -91,8 +91,8 @@ type Config struct {
 	Certs    *grafeas.CertConfig
 }
 
-// MetadataClient returns metadata.Fetcher based on the admission control config
-func MetadataClient(config *Config) (metadata.Fetcher, error) {
+// MetadataClient returns metadata.ReadWriteClient based on the admission control config
+func MetadataClient(config *Config) (metadata.ReadWriteClient, error) {
 	if config.Metadata == constants.GrafeasMetadata {
 		return grafeas.New(config.Grafeas, config.Certs)
 	}
@@ -406,5 +406,5 @@ func getReviewer() reviewer {
 // reviewer interface defines Kritis Reviewer struct, useful for mocking in tests
 type reviewer interface {
 	ReviewGAP(images []string, isps []kritis.GenericAttestationPolicy, pod *v1.Pod, c metadata.ReadOnlyClient) error
-	ReviewISP(images []string, isps []kritis.ImageSecurityPolicy, pod *v1.Pod, c metadata.Fetcher) error
+	ReviewISP(images []string, isps []kritis.ImageSecurityPolicy, pod *v1.Pod, c metadata.ReadWriteClient) error
 }

--- a/pkg/kritis/admission/admission.go
+++ b/pkg/kritis/admission/admission.go
@@ -48,9 +48,10 @@ type config struct {
 	retrievePod                     func(r *http.Request) (*v1.Pod, v1beta1.AdmissionReview, error)
 	retrieveDeployment              func(r *http.Request) (*appsv1.Deployment, v1beta1.AdmissionReview, error)
 	fetchMetadataClient             func(config *Config) (metadata.Fetcher, error)
+	fetchMetadataReadOnlyClient     func(config *Config) (metadata.ReadOnlyClient, error)
 	fetchGenericAttestationPolicies func(namespace string) ([]kritis.GenericAttestationPolicy, error)
 	fetchImageSecurityPolicies      func(namespace string) ([]kritis.ImageSecurityPolicy, error)
-	reviewer                        func(metadata.Fetcher) reviewer
+	reviewer                        func() reviewer
 }
 
 // Define constants for metav1.Status.Status
@@ -69,6 +70,7 @@ var (
 		retrievePod:                     unmarshalPod,
 		retrieveDeployment:              unmarshalDeployment,
 		fetchMetadataClient:             MetadataClient,
+		fetchMetadataReadOnlyClient:     MetadataReadOnlyClient,
 		fetchGenericAttestationPolicies: genericattestation.Policies,
 		fetchImageSecurityPolicies:      securitypolicy.ImageSecurityPolicies,
 		reviewer:                        getReviewer,
@@ -91,6 +93,17 @@ type Config struct {
 
 // MetadataClient returns metadata.Fetcher based on the admission control config
 func MetadataClient(config *Config) (metadata.Fetcher, error) {
+	if config.Metadata == constants.GrafeasMetadata {
+		return grafeas.New(config.Grafeas, config.Certs)
+	}
+	if config.Metadata == constants.ContainerAnalysisMetadata {
+		return containeranalysis.NewCache()
+	}
+	return nil, fmt.Errorf("unsupported backend %v", config.Metadata)
+}
+
+// MetadataReadOnlyClient returns metadata.ReadOnlyClient based on the admission control config
+func MetadataReadOnlyClient(config *Config) (metadata.ReadOnlyClient, error) {
 	if config.Metadata == constants.GrafeasMetadata {
 		return grafeas.New(config.Grafeas, config.Certs)
 	}
@@ -243,16 +256,6 @@ func createDeniedResponse(ar *v1beta1.AdmissionReview, message string) {
 func reviewImages(images []string, ns string, pod *v1.Pod, ar *v1beta1.AdmissionReview, config *Config) {
 	// NOTE: pod may be nil if we are reviewing images for a replica set.
 	glog.Infof("Reviewing images for %s in namespace %s: %s", pod, ns, images)
-	client, err := admissionConfig.fetchMetadataClient(config)
-	defer client.Close()
-
-	if err != nil {
-		errMsg := fmt.Sprintf("error getting metadata client: %v", err)
-		glog.Errorf(errMsg)
-		createDeniedResponse(ar, errMsg)
-		return
-	}
-
 	gaps, err := admissionConfig.fetchGenericAttestationPolicies(ns)
 	if err != nil {
 		errMsg := fmt.Sprintf("error getting generic attestation policies: %v", err)
@@ -264,7 +267,7 @@ func reviewImages(images []string, ns string, pod *v1.Pod, ar *v1beta1.Admission
 		glog.Infof("No Generic Attestation Policies found in namespace %s", ns)
 	} else {
 		glog.Infof("Found %d Generic Attestation Policies", len(gaps))
-		reviewGenericAttestationPolicy(images, ns, pod, ar, client, gaps)
+		reviewGenericAttestationPolicy(images, ns, pod, ar, gaps, config)
 	}
 
 	isps, err := admissionConfig.fetchImageSecurityPolicies(ns)
@@ -278,21 +281,41 @@ func reviewImages(images []string, ns string, pod *v1.Pod, ar *v1beta1.Admission
 		glog.Infof("No ISPs found in namespace %s", ns)
 	} else {
 		glog.Infof("Found %d ISPs to review image against", len(isps))
-		reviewImageSecurityPolicy(images, ns, pod, ar, client, isps)
+		reviewImageSecurityPolicy(images, ns, pod, ar, isps, config)
 	}
 }
 
-func reviewImageSecurityPolicy(images []string, ns string, pod *v1.Pod, ar *v1beta1.AdmissionReview, mc metadata.Fetcher, isps []kritis.ImageSecurityPolicy) {
-	r := admissionConfig.reviewer(mc)
-	if err := r.ReviewISP(images, isps, pod); err != nil {
+func reviewImageSecurityPolicy(images []string, ns string, pod *v1.Pod, ar *v1beta1.AdmissionReview, isps []kritis.ImageSecurityPolicy, config *Config) {
+	client, err := admissionConfig.fetchMetadataClient(config)
+	defer client.Close()
+
+	if err != nil {
+		errMsg := fmt.Sprintf("error getting metadata client: %v", err)
+		glog.Errorf(errMsg)
+		createDeniedResponse(ar, errMsg)
+		return
+	}
+
+	r := admissionConfig.reviewer()
+	if err := r.ReviewISP(images, isps, pod, client); err != nil {
 		glog.Infof("Denying %s in namespace %s: %v", pod, ns, err)
 		createDeniedResponse(ar, err.Error())
 	}
 }
 
-func reviewGenericAttestationPolicy(images []string, ns string, pod *v1.Pod, ar *v1beta1.AdmissionReview, mc metadata.Fetcher, gaps []kritis.GenericAttestationPolicy) {
-	r := admissionConfig.reviewer(mc)
-	if err := r.ReviewGAP(images, gaps, pod); err != nil {
+func reviewGenericAttestationPolicy(images []string, ns string, pod *v1.Pod, ar *v1beta1.AdmissionReview, gaps []kritis.GenericAttestationPolicy, config *Config) {
+	client, err := admissionConfig.fetchMetadataReadOnlyClient(config)
+	defer client.Close()
+
+	if err != nil {
+		errMsg := fmt.Sprintf("error getting metadata client: %v", err)
+		glog.Errorf(errMsg)
+		createDeniedResponse(ar, errMsg)
+		return
+	}
+
+	r := admissionConfig.reviewer()
+	if err := r.ReviewGAP(images, gaps, pod, client); err != nil {
 		glog.Infof("Denying %s in namespace %s: %v", pod, ns, err)
 		createDeniedResponse(ar, err.Error())
 	}
@@ -370,8 +393,8 @@ func checkBreakglass(meta *metav1.ObjectMeta) bool {
 	return ok
 }
 
-func getReviewer(client metadata.Fetcher) reviewer {
-	return review.New(client, &review.Config{
+func getReviewer() reviewer {
+	return review.New(&review.Config{
 		Strategy:  defaultViolationStrategy,
 		IsWebhook: true,
 		Secret:    secrets.Fetch,
@@ -382,6 +405,6 @@ func getReviewer(client metadata.Fetcher) reviewer {
 
 // reviewer interface defines Kritis Reviewer struct, useful for mocking in tests
 type reviewer interface {
-	ReviewGAP(images []string, isps []kritis.GenericAttestationPolicy, pod *v1.Pod) error
-	ReviewISP(images []string, isps []kritis.ImageSecurityPolicy, pod *v1.Pod) error
+	ReviewGAP(images []string, isps []kritis.GenericAttestationPolicy, pod *v1.Pod, c metadata.ReadOnlyClient) error
+	ReviewISP(images []string, isps []kritis.ImageSecurityPolicy, pod *v1.Pod, c metadata.Fetcher) error
 }

--- a/pkg/kritis/admission/admission_test.go
+++ b/pkg/kritis/admission/admission_test.go
@@ -115,13 +115,16 @@ func Test_AdmissionResponse(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			mReviewer := func(client metadata.Fetcher) reviewer {
+			mReviewer := func() reviewer {
 				return testutil.NewReviewer(tc.reviewGAPErr, tc.reviewISPErr, tc.expectedMsg)
 			}
 			mockConfig := config{
 				retrievePod: mockValidPod(),
 				fetchMetadataClient: func(config *Config) (metadata.Fetcher, error) {
 					return testutil.NilFetcher()()
+				},
+				fetchMetadataReadOnlyClient: func(config *Config) (metadata.ReadOnlyClient, error) {
+					return testutil.NilReadOnlyClient()()
 				},
 				fetchGenericAttestationPolicies: mockGAP,
 				fetchImageSecurityPolicies:      mockISP,

--- a/pkg/kritis/admission/admission_test.go
+++ b/pkg/kritis/admission/admission_test.go
@@ -120,7 +120,7 @@ func Test_AdmissionResponse(t *testing.T) {
 			}
 			mockConfig := config{
 				retrievePod: mockValidPod(),
-				fetchMetadataClient: func(config *Config) (metadata.Fetcher, error) {
+				fetchMetadataClient: func(config *Config) (metadata.ReadWriteClient, error) {
 					return testutil.NilFetcher()()
 				},
 				fetchMetadataReadOnlyClient: func(config *Config) (metadata.ReadOnlyClient, error) {

--- a/pkg/kritis/admission/admission_test.go
+++ b/pkg/kritis/admission/admission_test.go
@@ -121,7 +121,7 @@ func Test_AdmissionResponse(t *testing.T) {
 			mockConfig := config{
 				retrievePod: mockValidPod(),
 				fetchMetadataClient: func(config *Config) (metadata.ReadWriteClient, error) {
-					return testutil.NilFetcher()()
+					return testutil.NilReadWriteClient()()
 				},
 				fetchMetadataReadOnlyClient: func(config *Config) (metadata.ReadOnlyClient, error) {
 					return testutil.NilReadOnlyClient()()

--- a/pkg/kritis/crd/securitypolicy/securitypolicy.go
+++ b/pkg/kritis/crd/securitypolicy/securitypolicy.go
@@ -31,7 +31,7 @@ import (
 )
 
 // ValidateFunc defines the type for Validating Image Security Policies
-type ValidateFunc func(isp v1beta1.ImageSecurityPolicy, image string, client metadata.Fetcher) ([]policy.Violation, error)
+type ValidateFunc func(isp v1beta1.ImageSecurityPolicy, image string, client metadata.ReadWriteClient) ([]policy.Violation, error)
 
 // ImageSecurityPolicies returns all ISPs in the specified namespaces
 // Pass in an empty string to get all ISPs in all namespaces
@@ -54,7 +54,7 @@ func ImageSecurityPolicies(namespace string) ([]v1beta1.ImageSecurityPolicy, err
 
 // ValidateImageSecurityPolicy checks if an image satisfies ISP requirements
 // It returns a list of vulnerabilities that don't pass
-func ValidateImageSecurityPolicy(isp v1beta1.ImageSecurityPolicy, image string, client metadata.Fetcher) ([]policy.Violation, error) {
+func ValidateImageSecurityPolicy(isp v1beta1.ImageSecurityPolicy, image string, client metadata.ReadWriteClient) ([]policy.Violation, error) {
 	// First, check if image is allowed
 	if imageInAllowlist(isp, image) {
 		return nil, nil

--- a/pkg/kritis/cron/cron.go
+++ b/pkg/kritis/cron/cron.go
@@ -96,7 +96,7 @@ func Start(ctx context.Context, cfg Config, checkInterval time.Duration) {
 
 // CheckPods checks all running pods against defined policies.
 func CheckPods(cfg Config, isps []v1beta1.ImageSecurityPolicy) error {
-	r := review.New(cfg.Client, cfg.ReviewConfig)
+	r := review.New(cfg.ReviewConfig)
 	for _, isp := range isps {
 		ps, err := cfg.PodLister(isp.Namespace)
 		if err != nil {
@@ -104,7 +104,7 @@ func CheckPods(cfg Config, isps []v1beta1.ImageSecurityPolicy) error {
 		}
 		for _, p := range ps {
 			glog.Infof("Checking po %s", p.Name)
-			if err := r.ReviewISP(admission.PodImages(p), isps, &p); err != nil {
+			if err := r.ReviewISP(admission.PodImages(p), isps, &p, cfg.Client); err != nil {
 				glog.Error(err)
 			}
 		}

--- a/pkg/kritis/cron/cron.go
+++ b/pkg/kritis/cron/cron.go
@@ -45,7 +45,7 @@ type podLister func(string) ([]corev1.Pod, error)
 
 type Config struct {
 	PodLister            podLister
-	Client               metadata.Fetcher
+	Client               metadata.ReadWriteClient
 	ReviewConfig         *review.Config
 	SecurityPolicyLister func(namespace string) ([]v1beta1.ImageSecurityPolicy, error)
 }
@@ -54,7 +54,7 @@ var (
 	defaultViolationStrategy = &violation.AnnotationStrategy{}
 )
 
-func NewCronConfig(cs *kubernetes.Clientset, client metadata.Fetcher) *Config {
+func NewCronConfig(cs *kubernetes.Clientset, client metadata.ReadWriteClient) *Config {
 
 	cfg := Config{
 		PodLister: pods.Pods,

--- a/pkg/kritis/cron/cron_test.go
+++ b/pkg/kritis/cron/cron_test.go
@@ -71,7 +71,7 @@ type imageViolations struct {
 	imageMap map[string]bool
 }
 
-func (iv *imageViolations) violationChecker(isp v1beta1.ImageSecurityPolicy, image string, client metadata.Fetcher) ([]policy.Violation, error) {
+func (iv *imageViolations) violationChecker(isp v1beta1.ImageSecurityPolicy, image string, client metadata.ReadWriteClient) ([]policy.Violation, error) {
 	if ok := iv.imageMap[image]; ok {
 		v := securitypolicy.NewViolation(&metadata.Vulnerability{Severity: "foo"}, 0, "")
 		vs := []policy.Violation{}

--- a/pkg/kritis/gcbsigner/signer.go
+++ b/pkg/kritis/gcbsigner/signer.go
@@ -29,7 +29,7 @@ import (
 
 type Signer struct {
 	config *Config
-	client metadata.Fetcher
+	client metadata.ReadWriteClient
 }
 
 type Config struct {
@@ -37,7 +37,7 @@ type Config struct {
 	Validate buildpolicy.ValidateFunc
 }
 
-func New(client metadata.Fetcher, c *Config) Signer {
+func New(client metadata.ReadWriteClient, c *Config) Signer {
 	return Signer{
 		client: client,
 		config: c,

--- a/pkg/kritis/metadata/containeranalysis/cache.go
+++ b/pkg/kritis/metadata/containeranalysis/cache.go
@@ -24,9 +24,9 @@ import (
 )
 
 // Cache struct defines Cache for container analysis client.
-// Implements Fetcher interface.
+// Implements ReadWriteClient interface.
 type Cache struct {
-	client metadata.Fetcher
+	client metadata.ReadWriteClient
 	vuln   map[string][]metadata.Vulnerability
 	att    map[string][]metadata.PGPAttestation
 	notes  map[*kritisv1beta1.AttestationAuthority]*grafeas.Note

--- a/pkg/kritis/metadata/containeranalysis/cache.go
+++ b/pkg/kritis/metadata/containeranalysis/cache.go
@@ -24,6 +24,7 @@ import (
 )
 
 // Cache struct defines Cache for container analysis client.
+// Implements Fetcher interface.
 type Cache struct {
 	client metadata.Fetcher
 	vuln   map[string][]metadata.Vulnerability

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis.go
@@ -40,12 +40,13 @@ const (
 	AttestationAuthority = "ATTESTATION_AUTHORITY"
 )
 
-// Client struct implements Fetcher Interface.
+// Client struct implements Fetcher and ReadOnlyClient interfaces.
 type Client struct {
 	client *ca.GrafeasV1Beta1Client
 	ctx    context.Context
 }
 
+// TODO: separate constructor methods for r/w and r/o clients
 func New() (*Client, error) {
 	ctx := context.Background()
 	client, err := ca.NewGrafeasV1Beta1Client(ctx)

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis.go
@@ -40,7 +40,7 @@ const (
 	AttestationAuthority = "ATTESTATION_AUTHORITY"
 )
 
-// Client struct implements Fetcher and ReadOnlyClient interfaces.
+// Client struct implements ReadWriteClient and ReadOnlyClient interfaces.
 type Client struct {
 	client *ca.GrafeasV1Beta1Client
 	ctx    context.Context

--- a/pkg/kritis/metadata/grafeas/grafeas.go
+++ b/pkg/kritis/metadata/grafeas/grafeas.go
@@ -44,7 +44,7 @@ const (
 	DefaultProject       = "kritis" // DefaultProject is the default project name, only single project is supported
 )
 
-// Client implements the Fetcher interface using grafeas API.
+// Client implements the Fetcher and ReadOnlyClient interfaces using grafeas API.
 type Client struct {
 	client grafeas.GrafeasV1Beta1Client
 	ctx    context.Context
@@ -61,6 +61,7 @@ func ValidateConfig(config kritisv1beta1.GrafeasConfigSpec) error {
 	return nil
 }
 
+// TODO: separate constructor methods for r/w and r/o clients
 func New(config kritisv1beta1.GrafeasConfigSpec, certs *CertConfig) (*Client, error) {
 	if err := ValidateConfig(config); err != nil {
 		return nil, err

--- a/pkg/kritis/metadata/grafeas/grafeas.go
+++ b/pkg/kritis/metadata/grafeas/grafeas.go
@@ -44,7 +44,7 @@ const (
 	DefaultProject       = "kritis" // DefaultProject is the default project name, only single project is supported
 )
 
-// Client implements the Fetcher and ReadOnlyClient interfaces using grafeas API.
+// Client implements the ReadWriteClient and ReadOnlyClient interfaces using grafeas API.
 type Client struct {
 	client grafeas.GrafeasV1Beta1Client
 	ctx    context.Context

--- a/pkg/kritis/metadata/metadata.go
+++ b/pkg/kritis/metadata/metadata.go
@@ -25,6 +25,7 @@ import (
 	grafeasv1beta1 "google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1/grafeas"
 )
 
+// Read/write interface to access Occurrences and Notes using Grafeas API.
 type Fetcher interface {
 	// Vulnerabilities returns package vulnerabilities for a given image.
 	Vulnerabilities(containerImage string) ([]Vulnerability, error)
@@ -36,6 +37,18 @@ type Fetcher interface {
 	AttestationNote(aa *kritisv1beta1.AttestationAuthority) (*grafeasv1beta1.Note, error)
 	// Create Attestation Note for an Attestation Authority.
 	CreateAttestationNote(aa *kritisv1beta1.AttestationAuthority) (*grafeasv1beta1.Note, error)
+	//Attestations get Attestation Occurrences for given image.
+	Attestations(containerImage string, aa *kritisv1beta1.AttestationAuthority) ([]PGPAttestation, error)
+	// Close closes client connections
+	Close()
+}
+
+// Read-only interface to access Occurrences and Notes using Grafeas API.
+type ReadOnlyClient interface {
+	// Vulnerabilities returns package vulnerabilities for a given image.
+	Vulnerabilities(containerImage string) ([]Vulnerability, error)
+	//AttestationNote fetches an Attestation note for an Attestation Authority.
+	AttestationNote(aa *kritisv1beta1.AttestationAuthority) (*grafeasv1beta1.Note, error)
 	//Attestations get Attestation Occurrences for given image.
 	Attestations(containerImage string, aa *kritisv1beta1.AttestationAuthority) ([]PGPAttestation, error)
 	// Close closes client connections

--- a/pkg/kritis/metadata/metadata.go
+++ b/pkg/kritis/metadata/metadata.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Read/write interface to access Occurrences and Notes using Grafeas API.
-type Fetcher interface {
+type ReadWriteClient interface {
 	// Vulnerabilities returns package vulnerabilities for a given image.
 	Vulnerabilities(containerImage string) ([]Vulnerability, error)
 	// CreateAttestationOccurrence creates an Attestation occurrence for a given image, secret, and project.

--- a/pkg/kritis/metadata/metadata.go
+++ b/pkg/kritis/metadata/metadata.go
@@ -47,8 +47,6 @@ type Fetcher interface {
 type ReadOnlyClient interface {
 	// Vulnerabilities returns package vulnerabilities for a given image.
 	Vulnerabilities(containerImage string) ([]Vulnerability, error)
-	//AttestationNote fetches an Attestation note for an Attestation Authority.
-	AttestationNote(aa *kritisv1beta1.AttestationAuthority) (*grafeasv1beta1.Note, error)
 	//Attestations get Attestation Occurrences for given image.
 	Attestations(containerImage string, aa *kritisv1beta1.AttestationAuthority) ([]PGPAttestation, error)
 	// Close closes client connections

--- a/pkg/kritis/review/review.go
+++ b/pkg/kritis/review/review.go
@@ -91,7 +91,7 @@ func (r Reviewer) ReviewGAP(images []string, gaps []v1beta1.GenericAttestationPo
 
 // ReviewISP reviews images against image security policies
 // Returns error if violations are found and handles them per violation strategy
-func (r Reviewer) ReviewISP(images []string, isps []v1beta1.ImageSecurityPolicy, pod *v1.Pod, c metadata.Fetcher) error {
+func (r Reviewer) ReviewISP(images []string, isps []v1beta1.ImageSecurityPolicy, pod *v1.Pod, c metadata.ReadWriteClient) error {
 	images = util.RemoveGloballyAllowedImages(images)
 	if len(images) == 0 {
 		glog.Infof("images are all globally allowed, returning successful status: %s", images)
@@ -176,7 +176,7 @@ func (r Reviewer) handleViolations(image string, pod *v1.Pod, violations []polic
 }
 
 // Create attestations for 'image' by all 'auths'.
-func (r Reviewer) addAttestations(image string, isp v1beta1.ImageSecurityPolicy, auths []v1beta1.AttestationAuthority, c metadata.Fetcher) error {
+func (r Reviewer) addAttestations(image string, isp v1beta1.ImageSecurityPolicy, auths []v1beta1.AttestationAuthority, c metadata.ReadWriteClient) error {
 	errMsgs := []string{}
 	for _, a := range auths {
 		// Get or Create Note for this this Authority

--- a/pkg/kritis/review/review.go
+++ b/pkg/kritis/review/review.go
@@ -34,7 +34,6 @@ import (
 
 type Reviewer struct {
 	config *Config
-	client metadata.Fetcher
 }
 
 type Config struct {
@@ -45,16 +44,15 @@ type Config struct {
 	IsWebhook bool
 }
 
-func New(client metadata.Fetcher, c *Config) Reviewer {
+func New(c *Config) Reviewer {
 	return Reviewer{
-		client: client,
 		config: c,
 	}
 }
 
 // ReviewGAP reviews images against generic attestation policies
 // Returns error if violations are found and handles them per violation strategy
-func (r Reviewer) ReviewGAP(images []string, gaps []v1beta1.GenericAttestationPolicy, pod *v1.Pod) error {
+func (r Reviewer) ReviewGAP(images []string, gaps []v1beta1.GenericAttestationPolicy, pod *v1.Pod, c metadata.ReadOnlyClient) error {
 	images = util.RemoveGloballyAllowedImages(images)
 	if len(images) == 0 {
 		glog.Infof("images are all globally allowed, returning successful status: %s", images)
@@ -76,7 +74,7 @@ func (r Reviewer) ReviewGAP(images []string, gaps []v1beta1.GenericAttestationPo
 			if err != nil {
 				return err
 			}
-			_, attestedByAny := r.findUnsatisfiedAuths(image, auths)
+			_, attestedByAny := r.findUnsatisfiedAuths(image, auths, c)
 			if attestedByAny {
 				imgAttested = true
 			}
@@ -93,7 +91,7 @@ func (r Reviewer) ReviewGAP(images []string, gaps []v1beta1.GenericAttestationPo
 
 // ReviewISP reviews images against image security policies
 // Returns error if violations are found and handles them per violation strategy
-func (r Reviewer) ReviewISP(images []string, isps []v1beta1.ImageSecurityPolicy, pod *v1.Pod) error {
+func (r Reviewer) ReviewISP(images []string, isps []v1beta1.ImageSecurityPolicy, pod *v1.Pod, c metadata.Fetcher) error {
 	images = util.RemoveGloballyAllowedImages(images)
 	if len(images) == 0 {
 		glog.Infof("images are all globally allowed, returning successful status: %s", images)
@@ -112,7 +110,7 @@ func (r Reviewer) ReviewISP(images []string, isps []v1beta1.ImageSecurityPolicy,
 		}
 		for _, image := range images {
 			glog.Infof("Check if %s as valid Attestations.", image)
-			notAttestedBy, imgAttested := r.findUnsatisfiedAuths(image, auths)
+			notAttestedBy, imgAttested := r.findUnsatisfiedAuths(image, auths, c)
 
 			if err := r.config.Strategy.HandleAttestation(image, pod, imgAttested); err != nil {
 				glog.Errorf("error handling attestations %v", err)
@@ -124,7 +122,7 @@ func (r Reviewer) ReviewISP(images []string, isps []v1beta1.ImageSecurityPolicy,
 			}
 
 			glog.Infof("Getting vulnz for %s", image)
-			violations, err := r.config.Validate(isp, image, r.client)
+			violations, err := r.config.Validate(isp, image, c)
 			if err != nil {
 				return fmt.Errorf("error validating image security policy %v", err)
 			}
@@ -132,7 +130,7 @@ func (r Reviewer) ReviewISP(images []string, isps []v1beta1.ImageSecurityPolicy,
 				return r.handleViolations(image, pod, violations)
 			}
 			if r.config.IsWebhook {
-				if err := r.addAttestations(image, isp, notAttestedBy); err != nil {
+				if err := r.addAttestations(image, isp, notAttestedBy, c); err != nil {
 					glog.Errorf("error adding attestations %s", err)
 				}
 			}
@@ -143,11 +141,11 @@ func (r Reviewer) ReviewISP(images []string, isps []v1beta1.ImageSecurityPolicy,
 }
 
 // Returns a subset of 'auths' for which there are no attestations for 'image', as well as an indicator if any auth satisfies image.
-func (r Reviewer) findUnsatisfiedAuths(image string, auths []v1beta1.AttestationAuthority) ([]v1beta1.AttestationAuthority, bool) {
+func (r Reviewer) findUnsatisfiedAuths(image string, auths []v1beta1.AttestationAuthority, c metadata.ReadOnlyClient) ([]v1beta1.AttestationAuthority, bool) {
 	notAttestedBy := []v1beta1.AttestationAuthority{}
 	attestedByAny := false
 	for _, auth := range auths {
-		transport := AttestorValidatingTransport{Client: r.client, Attestor: auth}
+		transport := AttestorValidatingTransport{Client: c, Attestor: auth}
 		attestations, err := transport.GetValidatedAttestations(image)
 		if err != nil {
 			glog.Errorf("Error fetching validated attestations for %s: %v", image, err)
@@ -178,11 +176,11 @@ func (r Reviewer) handleViolations(image string, pod *v1.Pod, violations []polic
 }
 
 // Create attestations for 'image' by all 'auths'.
-func (r Reviewer) addAttestations(image string, isp v1beta1.ImageSecurityPolicy, auths []v1beta1.AttestationAuthority) error {
+func (r Reviewer) addAttestations(image string, isp v1beta1.ImageSecurityPolicy, auths []v1beta1.AttestationAuthority, c metadata.Fetcher) error {
 	errMsgs := []string{}
 	for _, a := range auths {
 		// Get or Create Note for this this Authority
-		n, err := util.GetOrCreateAttestationNote(r.client, &a)
+		n, err := util.GetOrCreateAttestationNote(c, &a)
 		if err != nil {
 			errMsgs = append(errMsgs, err.Error())
 		}
@@ -192,7 +190,7 @@ func (r Reviewer) addAttestations(image string, isp v1beta1.ImageSecurityPolicy,
 			errMsgs = append(errMsgs, err.Error())
 		}
 		// Create Attestation Signature
-		if _, err := r.client.CreateAttestationOccurrence(n, image, s, grafeas.DefaultProject); err != nil {
+		if _, err := c.CreateAttestationOccurrence(n, image, s, grafeas.DefaultProject); err != nil {
 			errMsgs = append(errMsgs, err.Error())
 		}
 

--- a/pkg/kritis/review/review_test.go
+++ b/pkg/kritis/review/review_test.go
@@ -118,7 +118,7 @@ func TestReviewGAP(t *testing.T) {
 		}
 		return &auth, nil
 	}
-	mockValidate := func(isp v1beta1.ImageSecurityPolicy, image string, client metadata.Fetcher) ([]policy.Violation, error) {
+	mockValidate := func(isp v1beta1.ImageSecurityPolicy, image string, client metadata.ReadWriteClient) ([]policy.Violation, error) {
 		return nil, nil
 	}
 
@@ -251,7 +251,7 @@ func TestReviewISP(t *testing.T) {
 				PublicKeyData:        base64.StdEncoding.EncodeToString([]byte(pub)),
 			}}, nil
 	}
-	mockValidate := func(_ v1beta1.ImageSecurityPolicy, image string, _ metadata.Fetcher) ([]policy.Violation, error) {
+	mockValidate := func(_ v1beta1.ImageSecurityPolicy, image string, _ metadata.ReadWriteClient) ([]policy.Violation, error) {
 		if image == vulnImage {
 			v := securitypolicy.NewViolation(&metadata.Vulnerability{Severity: "foo"}, 1, "")
 			vs := []policy.Violation{}

--- a/pkg/kritis/review/review_test.go
+++ b/pkg/kritis/review/review_test.go
@@ -196,14 +196,14 @@ func TestReviewGAP(t *testing.T) {
 			cMock := &testutil.MockMetadataClient{
 				PGPAttestations: tc.attestations,
 			}
-			r := New(cMock, &Config{
+			r := New(&Config{
 				Validate:  mockValidate,
 				Secret:    sMock,
 				Auths:     authMock,
 				IsWebhook: true,
 				Strategy:  &th,
 			})
-			if err := r.ReviewGAP([]string{tc.image}, tc.policies, nil); (err != nil) != tc.shouldErr {
+			if err := r.ReviewGAP([]string{tc.image}, tc.policies, nil, cMock); (err != nil) != tc.shouldErr {
 				t.Errorf("expected review to return error %t, actual error %s", tc.shouldErr, err)
 			}
 			if th.Attestations[tc.image] != tc.isAttested {
@@ -385,14 +385,14 @@ func TestReviewISP(t *testing.T) {
 			cMock := &testutil.MockMetadataClient{
 				PGPAttestations: tc.attestations,
 			}
-			r := New(cMock, &Config{
+			r := New(&Config{
 				Validate:  mockValidate,
 				Secret:    sMock,
 				Auths:     authMock,
 				IsWebhook: tc.isWebhook,
 				Strategy:  &th,
 			})
-			if err := r.ReviewISP([]string{tc.image}, isps, nil); (err != nil) != tc.shouldErr {
+			if err := r.ReviewISP([]string{tc.image}, isps, nil, cMock); (err != nil) != tc.shouldErr {
 				t.Errorf("expected review to return error %t, actual error %s", tc.shouldErr, err)
 			}
 			if len(th.Violations) != tc.handledViolations {
@@ -456,7 +456,7 @@ func TestGetAttestationAuthoritiesForGAP(t *testing.T) {
 		return &a, nil
 	}
 
-	r := New(nil, &Config{
+	r := New(&Config{
 		Auths: authMock,
 	})
 	tcs := []struct {
@@ -526,7 +526,7 @@ func TestGetAttestationAuthoritiesForISP(t *testing.T) {
 		return &a, nil
 	}
 
-	r := New(nil, &Config{
+	r := New(&Config{
 		Auths: authMock,
 	})
 	tcs := []struct {

--- a/pkg/kritis/review/validating_transport.go
+++ b/pkg/kritis/review/validating_transport.go
@@ -33,7 +33,7 @@ type ValidatingTransport interface {
 
 // Implements ValidatingTransport.
 type AttestorValidatingTransport struct {
-	Client   metadata.Fetcher
+	Client   metadata.ReadOnlyClient
 	Attestor v1beta1.AttestationAuthority
 }
 

--- a/pkg/kritis/testutil/metadata_mock.go
+++ b/pkg/kritis/testutil/metadata_mock.go
@@ -90,7 +90,7 @@ func (m *MockMetadataClient) Attestations(containerImage string, aa *kritisv1bet
 	return m.PGPAttestations, nil
 }
 
-func NilFetcher() func() (metadata.ReadWriteClient, error) {
+func NilReadWriteClient() func() (metadata.ReadWriteClient, error) {
 	return func() (metadata.ReadWriteClient, error) {
 		return &MockMetadataClient{
 			Vulnz:           []metadata.Vulnerability{},

--- a/pkg/kritis/testutil/metadata_mock.go
+++ b/pkg/kritis/testutil/metadata_mock.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1/grafeas"
 )
 
+// Implements Fetcher and ReadOnlyClient interfaces.
 type MockMetadataClient struct {
 	Vulnz           []metadata.Vulnerability
 	PGPAttestations []metadata.PGPAttestation
@@ -91,6 +92,16 @@ func (m *MockMetadataClient) Attestations(containerImage string, aa *kritisv1bet
 
 func NilFetcher() func() (metadata.Fetcher, error) {
 	return func() (metadata.Fetcher, error) {
+		return &MockMetadataClient{
+			Vulnz:           []metadata.Vulnerability{},
+			PGPAttestations: []metadata.PGPAttestation{},
+			AAs:             []kritisv1beta1.AttestationAuthority{},
+		}, nil
+	}
+}
+
+func NilReadOnlyClient() func() (metadata.ReadOnlyClient, error) {
+	return func() (metadata.ReadOnlyClient, error) {
 		return &MockMetadataClient{
 			Vulnz:           []metadata.Vulnerability{},
 			PGPAttestations: []metadata.PGPAttestation{},

--- a/pkg/kritis/testutil/metadata_mock.go
+++ b/pkg/kritis/testutil/metadata_mock.go
@@ -25,7 +25,7 @@ import (
 	"google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1/grafeas"
 )
 
-// Implements Fetcher and ReadOnlyClient interfaces.
+// Implements ReadWriteClient and ReadOnlyClient interfaces.
 type MockMetadataClient struct {
 	Vulnz           []metadata.Vulnerability
 	PGPAttestations []metadata.PGPAttestation
@@ -90,8 +90,8 @@ func (m *MockMetadataClient) Attestations(containerImage string, aa *kritisv1bet
 	return m.PGPAttestations, nil
 }
 
-func NilFetcher() func() (metadata.Fetcher, error) {
-	return func() (metadata.Fetcher, error) {
+func NilFetcher() func() (metadata.ReadWriteClient, error) {
+	return func() (metadata.ReadWriteClient, error) {
 		return &MockMetadataClient{
 			Vulnz:           []metadata.Vulnerability{},
 			PGPAttestations: []metadata.PGPAttestation{},

--- a/pkg/kritis/testutil/review_mock.go
+++ b/pkg/kritis/testutil/review_mock.go
@@ -45,7 +45,7 @@ func (r *ReviewerMock) ReviewGAP(images []string, isps []v1beta1.GenericAttestat
 	return fmt.Errorf(r.message)
 }
 
-func (r *ReviewerMock) ReviewISP(images []string, isps []v1beta1.ImageSecurityPolicy, pod *v1.Pod, c metadata.Fetcher) error {
+func (r *ReviewerMock) ReviewISP(images []string, isps []v1beta1.ImageSecurityPolicy, pod *v1.Pod, c metadata.ReadWriteClient) error {
 	if !r.hasISPErr {
 		return nil
 	}

--- a/pkg/kritis/testutil/review_mock.go
+++ b/pkg/kritis/testutil/review_mock.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
+	"github.com/grafeas/kritis/pkg/kritis/metadata"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -37,14 +38,14 @@ func NewReviewer(gapErr, ispErr bool, s string) *ReviewerMock {
 	}
 }
 
-func (r *ReviewerMock) ReviewGAP(images []string, isps []v1beta1.GenericAttestationPolicy, pod *v1.Pod) error {
+func (r *ReviewerMock) ReviewGAP(images []string, isps []v1beta1.GenericAttestationPolicy, pod *v1.Pod, c metadata.ReadOnlyClient) error {
 	if !r.hasGAPErr {
 		return nil
 	}
 	return fmt.Errorf(r.message)
 }
 
-func (r *ReviewerMock) ReviewISP(images []string, isps []v1beta1.ImageSecurityPolicy, pod *v1.Pod) error {
+func (r *ReviewerMock) ReviewISP(images []string, isps []v1beta1.ImageSecurityPolicy, pod *v1.Pod, c metadata.Fetcher) error {
 	if !r.hasISPErr {
 		return nil
 	}

--- a/pkg/kritis/util/util.go
+++ b/pkg/kritis/util/util.go
@@ -88,7 +88,7 @@ func GetAttestationKeyFingerprint(pgpSigningKey *secrets.PGPSigningSecret) strin
 }
 
 // GetOrCreateAttestationNote returns a note if exists and creates one if it does not exist.
-func GetOrCreateAttestationNote(c metadata.Fetcher, a *v1beta1.AttestationAuthority) (*grafeas.Note, error) {
+func GetOrCreateAttestationNote(c metadata.ReadWriteClient, a *v1beta1.AttestationAuthority) (*grafeas.Note, error) {
 	n, err := c.AttestationNote(a)
 	if err == nil {
 		return n, nil


### PR DESCRIPTION
This splits the general-purpose metadata.Fetcher into two:

- metadata.ReadOnlyClient: used in GAP, cannot mutate attestation storage, narrow interface
- metadata.ReadWriteClient: used in ISP and signer, has methods to mutate attestation storage

This PR will also make it easier to address https://github.com/grafeas/kritis/issues/420 by making it clear where and how metadata.AttestationNote() is used (notably: not in GAP review).