### PR TITLE
Bump kubectl version in helm hook containers

### DIFF
--- a/helm-hooks/Dockerfile
+++ b/helm-hooks/Dockerfile
@@ -22,7 +22,7 @@ RUN make ${stage}
 FROM golang:1.12
 RUN go get -u github.com/cloudflare/cfssl/cmd/...
 
-ENV KUBECTL_VERSION v1.10.0
+ENV KUBECTL_VERSION v1.16.4
 RUN curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl  && \
     chmod +x /usr/local/bin/kubectl
 


### PR DESCRIPTION
This is to address #434 