### PR TITLE
Move private secret key out of AttestationAuthority.

### DIFF
--- a/artifacts/examples/attestation-authority-example.yaml
+++ b/artifacts/examples/attestation-authority-example.yaml
@@ -5,4 +5,3 @@ metadata:
   namespace: default
 spec:
   noteReference: projects/kritis-test1
-  privateKeySecretName: kritis-authority-key

--- a/artifacts/examples/build-policy-example.yaml
+++ b/artifacts/examples/build-policy-example.yaml
@@ -5,5 +5,6 @@ metadata:
   namespace: default
 spec:
   attestationAuthorityName: kritis-authority
+  privateKeySecretName: kritis-authority-key
   buildRequirements:
     builtFrom: https://source.developers.google.com/p/binauthz-demo1-builder/r/demo-app:build.*

--- a/artifacts/examples/image-security-policy-example.yaml
+++ b/artifacts/examples/image-security-policy-example.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: default
 spec:
   attestationAuthorityName: kritis-authority
+  privateKeySecretName: kritis-authority-key
   imageAllowlist:
   - gcr.io/my/image
   packageVulnerabilityRequirements:

--- a/artifacts/integration-examples/image-security-policy-example.yaml
+++ b/artifacts/integration-examples/image-security-policy-example.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   attestationAuthorityNames:
   - test-attestor
+  privateKeySecretName: kritis-authority-key
   imageAllowlist:
   - gcr.io/kritis-int-test/nginx-digest-allowlist:latest
   - gcr.io/kritis-int-test/nginx-digest-allowlist@sha256:56e0af16f4a9d2401d3f55bc8d214d519f070b5317512c87568603f315a8be72

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -102,6 +102,7 @@ metadata:
     namespace: example-namespace
 spec:
   attestationAuthorityName: kritis-authority
+  privateKeySecretName: foo
   imageAllowlist:
   - gcr.io/my-project/allowlist-image@sha256:<DIGEST>
   packageVulnerabilityPolicy:
@@ -142,7 +143,8 @@ Image Security Policy Spec description:
 | Field     | Default (if applicable)   | Description |
 |-----------|---------------------------|-------------|
 |imageAllowlist | | List of images that are allowlisted and are not inspected by Admission Controller.|
-|attestationAuthorityName | | Attestation authority name for adding attestation.|
+|attestationAuthorityName | | Attestation authority name for verifying attestation.|
+|privateKeySecretname | | Private secret key name for adding attestation.|
 |packageVulnerabilityPolicy.allowlistCVEs |  | List of CVEs which will be ignored.|
 |packageVulnerabilityPolicy.maximumSeverity| ALLOW_ALL | Tolerance level for vulnerabilities found in the container image.|
 |packageVulnerabilityPolicy.maximumFixUnavailableSeverity |  ALLOW_ALL | The tolerance level for vulnerabilities found that have no fix available.|
@@ -202,7 +204,6 @@ metadata:
     namespace: qa
 spec:
     noteReference: projects/image-attestor
-    privateKeySecretName: foo
     publicKeyData: ...
 ```
 

--- a/docs/standalone/no_attestation.sh
+++ b/docs/standalone/no_attestation.sh
@@ -48,7 +48,6 @@ metadata:
   namespace: default
 spec:
   noteReference: v1beta1/projects/standalone
-  privateKeySecretName: attestor
   publicKeyData: $PUBLIC_KEY
 EOF
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -85,7 +85,6 @@
             namespace: default
         spec:
             noteReference: v1beta1/projects/$PROJECT
-            privateKeySecretName: my-attestor
             publicKeyData: $PUBLIC_KEY
         EOF
         ```

--- a/integration/crd.go
+++ b/integration/crd.go
@@ -38,11 +38,10 @@ metadata:
   name: test-attestor
 spec:
   noteReference: projects/%s
-  privateKeySecretName: %s
   publicKeyData: %s`
 )
 
-// Secret name for test-attestor
+// Secret name for test-attestor, which matches integration/testdata/image-security-policy/my-isp.yaml
 var aaSecret = "test-attestor"
 
 // CRDs is a map of CRD type to names of the expected CRDs to create.
@@ -112,7 +111,7 @@ func createFileWithContents(t *testing.T, d string, c string) string {
 func createAA(t *testing.T, project string, ns string, pubkey string) {
 	t.Helper()
 	cmd := exec.Command("kubectl", "apply", "-n", ns, "-f", "-")
-	cmd.Stdin = bytes.NewReader([]byte(fmt.Sprintf(testAttesationAuthority, project, aaSecret, pubkey)))
+	cmd.Stdin = bytes.NewReader([]byte(fmt.Sprintf(testAttesationAuthority, project, pubkey)))
 	if _, err := integration_util.RunCmdOut(cmd); err != nil {
 		t.Fatalf("testing error: %v", err)
 	}

--- a/integration/crd.go
+++ b/integration/crd.go
@@ -48,7 +48,7 @@ var crdNames = map[string]string{
 	"imagesecuritypolicies.kritis.grafeas.io": "my-isp",
 }
 
-func createKeySecret(t *testing.T, project string, ns string, pubKey string, privKey string) {
+func createKeySecret(t *testing.T, secretName string, ns string, pubKey string, privKey string) {
 	t.Helper()
 	// create a tmp dir for keys
 	d, err := ioutil.TempDir("", "_keys")
@@ -63,7 +63,7 @@ func createKeySecret(t *testing.T, project string, ns string, pubKey string, pri
 	privFile := createFileWithContents(t, d, privKey)
 
 	// Finally create a kubernetes secret.
-	cmd := exec.Command("kubectl", "create", "secret", "generic", aaSecret,
+	cmd := exec.Command("kubectl", "create", "secret", "generic", secretName,
 		fmt.Sprintf("--from-file=public=%s", pubFile),
 		fmt.Sprintf("--from-file=private=%s", privFile),
 		"-n", ns)

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -278,7 +278,13 @@ func setUp(t *testing.T) (kubernetes.Interface, *v1.Namespace, func(t *testing.T
 		t.Fatalf("install: %v", err)
 	}
 
-	createAttestationAuthority(t, *gcpProject, ns.Name)
+	// Generate a key value pair
+	pubKey, privKey := testutil.CreateKeyPair(t, aaSecret)
+	// Create key secret in k8s cluster
+	createKeySecret(t, *gcpProject, ns.Name, pubKey, privKey)
+	// Create AA in k8s cluster
+	createAA(t, project, ns, pubKey)
+
 	isp, err := processTemplate("image-security-policy/my-isp.yaml", ns.Name)
 	if err != nil {
 		t.Fatalf("failed to process isp template: %v", err)

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/grafeas/kritis/cmd/kritis/version"
 	integration_util "github.com/grafeas/kritis/pkg/kritis/integration_util"
 	kubernetesutil "github.com/grafeas/kritis/pkg/kritis/kubernetes"
+	testutil "github.com/grafeas/kritis/pkg/kritis/testutil"
 	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -281,9 +282,9 @@ func setUp(t *testing.T) (kubernetes.Interface, *v1.Namespace, func(t *testing.T
 	// Generate a key value pair
 	pubKey, privKey := testutil.CreateKeyPair(t, aaSecret)
 	// Create key secret in k8s cluster
-	createKeySecret(t, *gcpProject, ns.Name, pubKey, privKey)
+	createKeySecret(t, aaSecret, ns.Name, pubKey, privKey)
 	// Create AA in k8s cluster
-	createAA(t, project, ns, pubKey)
+	createAA(t, *gcpProject, ns.Name, pubKey)
 
 	isp, err := processTemplate("image-security-policy/my-isp.yaml", ns.Name)
 	if err != nil {

--- a/integration/testdata/image-security-policy/my-isp.yaml
+++ b/integration/testdata/image-security-policy/my-isp.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   attestationAuthorityNames:
   - test-attestor
+  privateKeySecretName: test-attestor
   imageAllowlist:
   - gcr.io/{{ .Project }}/nginx-digest-whitelist:latest
   - gcr.io/{{ .Project }}/nginx-digest-whitelist@sha256:56e0af16f4a9d2401d3f55bc8d214d519f070b5317512c87568603f315a8be72

--- a/pkg/kritis/apis/kritis/v1beta1/attestationauthority.go
+++ b/pkg/kritis/apis/kritis/v1beta1/attestationauthority.go
@@ -33,10 +33,9 @@ type AttestationAuthority struct {
 
 // AttestationAuthoritySpec is the spec for a AttestationAuthority resource
 type AttestationAuthoritySpec struct {
-	NoteReference        string `json:"noteReference"`
-	PrivateKeySecretName string `json:"privateKeySecretName"`
-	PublicKeyData        string `json:"publicKeyData"`
-	PolicyType           string `json:"policyType"`
+	NoteReference string `json:"noteReference"`
+	PublicKeyData string `json:"publicKeyData"`
+	PolicyType    string `json:"policyType"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/kritis/apis/kritis/v1beta1/buildpolicy.go
+++ b/pkg/kritis/apis/kritis/v1beta1/buildpolicy.go
@@ -34,6 +34,7 @@ type BuildPolicy struct {
 // BuildPolicySpec is the spec for a BuildPolicy resource
 type BuildPolicySpec struct {
 	AttestationAuthorityName string            `yaml:"attestationAuthorityName"`
+	PrivateKeySecretName     string            `yaml:"privateKeySecretName"`
 	BuildRequirements        BuildRequirements `yaml:"buildRequirements"`
 }
 

--- a/pkg/kritis/apis/kritis/v1beta1/securitypolicy.go
+++ b/pkg/kritis/apis/kritis/v1beta1/securitypolicy.go
@@ -36,6 +36,7 @@ type ImageSecurityPolicySpec struct {
 	ImageAllowlist                   []string                         `json:"imageAllowlist"`
 	PackageVulnerabilityRequirements PackageVulnerabilityRequirements `json:"packageVulnerabilityRequirements"`
 	AttestationAuthorityName         string                           `json:"attestationAuthorityName"`
+	PrivateKeySecretName             string                           `json:"privateKeySecretName"`
 }
 
 // PackageVulnerabilityRequirements is the requirements for package vulnz for an ImageSecurityPolicy

--- a/pkg/kritis/gcbsigner/signer.go
+++ b/pkg/kritis/gcbsigner/signer.go
@@ -73,7 +73,7 @@ func (s Signer) ValidateAndSign(prov BuildProvenance, bps []v1beta1.BuildPolicy)
 	return nil
 }
 
-func (s Signer) addAttestation(image string, ns string, authority string, keyName string) error {
+func (s Signer) addAttestation(image string, ns string, authority string, keySecretName string) error {
 	// Get AttestaionAuthority specified in the buildpolicy.
 	a, err := authFetcher(ns, authority)
 	if err != nil {
@@ -84,7 +84,7 @@ func (s Signer) addAttestation(image string, ns string, authority string, keyNam
 		return err
 	}
 	// Get secret for this Authority
-	sec, err := s.config.Secret(ns, keyName)
+	sec, err := s.config.Secret(ns, keySecretName)
 	if err != nil {
 		return err
 	}

--- a/pkg/kritis/gcbsigner/signer.go
+++ b/pkg/kritis/gcbsigner/signer.go
@@ -66,14 +66,14 @@ func (s Signer) ValidateAndSign(prov BuildProvenance, bps []v1beta1.BuildPolicy)
 			continue
 		}
 		glog.Infof("Image %q matches BuildPolicy %s, creating attestations", prov.ImageRef, bp.Name)
-		if err := s.addAttestation(prov.ImageRef, bp.Namespace, bp.Spec.AttestationAuthorityName); err != nil {
+		if err := s.addAttestation(prov.ImageRef, bp.Namespace, bp.Spec.AttestationAuthorityName, bp.Spec.PrivateKeySecretName); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (s Signer) addAttestation(image string, ns string, authority string) error {
+func (s Signer) addAttestation(image string, ns string, authority string, keyName string) error {
 	// Get AttestaionAuthority specified in the buildpolicy.
 	a, err := authFetcher(ns, authority)
 	if err != nil {
@@ -84,7 +84,7 @@ func (s Signer) addAttestation(image string, ns string, authority string) error 
 		return err
 	}
 	// Get secret for this Authority
-	sec, err := s.config.Secret(ns, a.Spec.PrivateKeySecretName)
+	sec, err := s.config.Secret(ns, keyName)
 	if err != nil {
 		return err
 	}

--- a/pkg/kritis/gcbsigner/signer_test.go
+++ b/pkg/kritis/gcbsigner/signer_test.go
@@ -52,6 +52,7 @@ func TestValidateAndSign(t *testing.T) {
 			},
 			Spec: v1beta1.BuildPolicySpec{
 				AttestationAuthorityName: "auth1",
+				PrivateKeySecretName:     "auth1_key",
 				BuildRequirements: v1beta1.BuildRequirements{
 					BuiltFrom: "single_attestor",
 				},
@@ -64,6 +65,7 @@ func TestValidateAndSign(t *testing.T) {
 			},
 			Spec: v1beta1.BuildPolicySpec{
 				AttestationAuthorityName: "auth2",
+				PrivateKeySecretName:     "auth2_key",
 				BuildRequirements: v1beta1.BuildRequirements{
 					BuiltFrom: "multi_attestor",
 				},
@@ -76,6 +78,7 @@ func TestValidateAndSign(t *testing.T) {
 			},
 			Spec: v1beta1.BuildPolicySpec{
 				AttestationAuthorityName: "auth3",
+				PrivateKeySecretName:     "auth3_key",
 				BuildRequirements: v1beta1.BuildRequirements{
 					BuiltFrom: "multi_attestor",
 				},
@@ -88,6 +91,7 @@ func TestValidateAndSign(t *testing.T) {
 			},
 			Spec: v1beta1.BuildPolicySpec{
 				AttestationAuthorityName: "auth4",
+				PrivateKeySecretName:     "missing_key",
 				BuildRequirements: v1beta1.BuildRequirements{
 					BuiltFrom: "no_key_attestor",
 				},
@@ -102,9 +106,8 @@ func TestValidateAndSign(t *testing.T) {
 					Namespace: "foo",
 				},
 				Spec: v1beta1.AttestationAuthoritySpec{
-					NoteReference:        "auth1_note",
-					PrivateKeySecretName: "auth1_key",
-					PublicKeyData:        pub1,
+					NoteReference: "auth1_note",
+					PublicKeyData: pub1,
 				},
 			},
 			{
@@ -113,9 +116,8 @@ func TestValidateAndSign(t *testing.T) {
 					Namespace: "foo",
 				},
 				Spec: v1beta1.AttestationAuthoritySpec{
-					NoteReference:        "auth2_note",
-					PrivateKeySecretName: "auth2_key",
-					PublicKeyData:        pub2,
+					NoteReference: "auth2_note",
+					PublicKeyData: pub2,
 				},
 			},
 			{
@@ -124,9 +126,8 @@ func TestValidateAndSign(t *testing.T) {
 					Namespace: "foo",
 				},
 				Spec: v1beta1.AttestationAuthoritySpec{
-					NoteReference:        "auth3_note",
-					PrivateKeySecretName: "auth3_key",
-					PublicKeyData:        pub3,
+					NoteReference: "auth3_note",
+					PublicKeyData: pub3,
 				},
 			},
 			{
@@ -135,8 +136,7 @@ func TestValidateAndSign(t *testing.T) {
 					Namespace: "foo",
 				},
 				Spec: v1beta1.AttestationAuthoritySpec{
-					NoteReference:        "auth4_note",
-					PrivateKeySecretName: "missing_key",
+					NoteReference: "auth4_note",
 				},
 			},
 		}

--- a/pkg/kritis/review/review.go
+++ b/pkg/kritis/review/review.go
@@ -210,7 +210,7 @@ func (r Reviewer) addAttestation(image string, isp v1beta1.ImageSecurityPolicy, 
 		errMsgs = append(errMsgs, err.Error())
 	}
 	// Get secret for this Authority
-	s, err := r.config.Secret(isp.Namespace, auth.Spec.PrivateKeySecretName)
+	s, err := r.config.Secret(isp.Namespace, isp.Spec.PrivateKeySecretName)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}

--- a/pkg/kritis/review/review_test.go
+++ b/pkg/kritis/review/review_test.go
@@ -97,16 +97,14 @@ func TestReviewGAP(t *testing.T) {
 			"test": {
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: v1beta1.AttestationAuthoritySpec{
-					NoteReference:        "provider/test",
-					PrivateKeySecretName: "test",
-					PublicKeyData:        base64.StdEncoding.EncodeToString([]byte(pub)),
+					NoteReference: "provider/test",
+					PublicKeyData: base64.StdEncoding.EncodeToString([]byte(pub)),
 				}},
 			"test2": {
 				ObjectMeta: metav1.ObjectMeta{Name: "test2"},
 				Spec: v1beta1.AttestationAuthoritySpec{
-					NoteReference:        "provider/test2",
-					PrivateKeySecretName: "test2",
-					PublicKeyData:        base64.StdEncoding.EncodeToString([]byte(pub2)),
+					NoteReference: "provider/test2",
+					PublicKeyData: base64.StdEncoding.EncodeToString([]byte(pub2)),
 				}}}
 		auth, exists := authMap[name]
 		if !exists {
@@ -251,6 +249,7 @@ func TestReviewISP(t *testing.T) {
 			},
 			Spec: v1beta1.ImageSecurityPolicySpec{
 				AttestationAuthorityName: "test",
+				PrivateKeySecretName:     "test",
 			},
 		},
 	}
@@ -258,9 +257,8 @@ func TestReviewISP(t *testing.T) {
 		return &v1beta1.AttestationAuthority{
 			ObjectMeta: metav1.ObjectMeta{Name: name},
 			Spec: v1beta1.AttestationAuthoritySpec{
-				NoteReference:        "provider/test",
-				PrivateKeySecretName: "test",
-				PublicKeyData:        base64.StdEncoding.EncodeToString([]byte(pub)),
+				NoteReference: "provider/test",
+				PublicKeyData: base64.StdEncoding.EncodeToString([]byte(pub)),
 			}}, nil
 	}
 	mockValidate := func(_ v1beta1.ImageSecurityPolicy, image string, _ metadata.ReadWriteClient) ([]policy.Violation, error) {
@@ -470,16 +468,14 @@ func TestGetAttestationAuthoritiesForGAP(t *testing.T) {
 		"a1": {
 			ObjectMeta: metav1.ObjectMeta{Name: "a1"},
 			Spec: v1beta1.AttestationAuthoritySpec{
-				NoteReference:        "provider/test",
-				PrivateKeySecretName: "test",
-				PublicKeyData:        "testdata",
+				NoteReference: "provider/test",
+				PublicKeyData: "testdata",
 			}},
 		"a2": {
 			ObjectMeta: metav1.ObjectMeta{Name: "a2"},
 			Spec: v1beta1.AttestationAuthoritySpec{
-				NoteReference:        "provider/test",
-				PrivateKeySecretName: "test",
-				PublicKeyData:        "testdata",
+				NoteReference: "provider/test",
+				PublicKeyData: "testdata",
 			}},
 	}
 	authMock := func(ns string, name string) (*v1beta1.AttestationAuthority, error) {
@@ -540,16 +536,14 @@ func TestGetAttestationAuthoritiesForISP(t *testing.T) {
 		"a1": {
 			ObjectMeta: metav1.ObjectMeta{Name: "a1"},
 			Spec: v1beta1.AttestationAuthoritySpec{
-				NoteReference:        "provider/test",
-				PrivateKeySecretName: "test",
-				PublicKeyData:        "testdata",
+				NoteReference: "provider/test",
+				PublicKeyData: "testdata",
 			}},
 		"a2": {
 			ObjectMeta: metav1.ObjectMeta{Name: "a2"},
 			Spec: v1beta1.AttestationAuthoritySpec{
-				NoteReference:        "provider/test",
-				PrivateKeySecretName: "test",
-				PublicKeyData:        "testdata",
+				NoteReference: "provider/test",
+				PublicKeyData: "testdata",
 			}},
 	}
 	authMock := func(ns string, name string) (*v1beta1.AttestationAuthority, error) {
@@ -594,6 +588,7 @@ func TestGetAttestationAuthoritiesForISP(t *testing.T) {
 			isp := v1beta1.ImageSecurityPolicy{
 				Spec: v1beta1.ImageSecurityPolicySpec{
 					AttestationAuthorityName: tc.aName,
+					PrivateKeySecretName:     "test",
 				},
 			}
 			a, err := r.getAttestationAuthorityForISP(isp)

--- a/pkg/kritis/review/validating_transport_test.go
+++ b/pkg/kritis/review/validating_transport_test.go
@@ -49,15 +49,13 @@ func TestValidatingTransport(t *testing.T) {
 	validAuth := v1beta1.AttestationAuthority{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-attestor"},
 		Spec: v1beta1.AttestationAuthoritySpec{
-			PrivateKeySecretName: "test-success",
-			PublicKeyData:        base64.StdEncoding.EncodeToString([]byte(pub)),
+			PublicKeyData: base64.StdEncoding.EncodeToString([]byte(pub)),
 		},
 	}
 	invalidAuth := v1beta1.AttestationAuthority{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-attestor"},
 		Spec: v1beta1.AttestationAuthoritySpec{
-			PrivateKeySecretName: "test-success",
-			PublicKeyData:        "bad-key",
+			PublicKeyData: "bad-key",
 		},
 	}
 	tcs := []struct {


### PR DESCRIPTION
This change is part of binauthz compatibility changes.
It will move private secret key name out of kritis attestation authority, and into the policies, i.e., the ISP policy and the build policy. 
The purpose of this is to separate the semantics of `signing` and `verifying`, leaving attestation authority to do only `verifying` and the respective policies to do `signing`.