### PR TITLE
Update ISP yamls to comply with PR#408

### DIFF
--- a/artifacts/integration-examples/image-security-policy-example.yaml
+++ b/artifacts/integration-examples/image-security-policy-example.yaml
@@ -3,8 +3,7 @@ kind: ImageSecurityPolicy
 metadata:
   name: my-isp
 spec:
-  attestationAuthorityNames:
-  - test-attestor
+  attestationAuthorityName: test-attestor
   imageAllowlist:
   - gcr.io/kritis-int-test/nginx-digest-allowlist:latest
   - gcr.io/kritis-int-test/nginx-digest-allowlist@sha256:56e0af16f4a9d2401d3f55bc8d214d519f070b5317512c87568603f315a8be72

--- a/integration/testdata/image-security-policy/my-isp.yaml
+++ b/integration/testdata/image-security-policy/my-isp.yaml
@@ -3,8 +3,7 @@ kind: ImageSecurityPolicy
 metadata:
   name: my-isp
 spec:
-  attestationAuthorityNames:
-  - test-attestor
+  attestationAuthorityName: test-attestor
   imageAllowlist:
   - gcr.io/{{ .Project }}/nginx-digest-whitelist:latest
   - gcr.io/{{ .Project }}/nginx-digest-whitelist@sha256:56e0af16f4a9d2401d3f55bc8d214d519f070b5317512c87568603f315a8be72


### PR DESCRIPTION
This PR will update yamls used in integration tests to comply with #408 .
Without this PR, integration tests should have broken.
It was not broken because we didn't check whether images are properly attested by ISP (see #447 )
Adding the right checks might be non-trivial. So this PR just fix the yamls for now.