### PR TITLE
Change ANY attestor to ALL attestor semantic in GAP.

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -90,7 +90,7 @@ Generic Attestation Policy Spec description:
 | attestationAuthorityNames | | Non-empty List of [Attestation Authorities](#attestationauthority-crd) for which all of them are required to be satisfied before the Admission Controller will admit the pod.|
 | attestationAuthorityNames | | List of [Attestation Authorities](#attestationauthority-crd) for which one of is required to be satisfied before the Admission Controller will admit the pod.|
 
-Note that the list of [Attestation Authorities](#attestationauthority-crd) must be non-empty. If the list is empty, images can only be admitted through allowlist (GAP allowlist is WIP).
+Note that the list of [Attestation Authorities](#attestationauthority-crd) must be non-empty. If the list is empty, an error will be thrown for malformed policy, and no image will be admitted, including allowlisted images.
 
 Admission Allowlist Pattern Spec description
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -36,7 +36,6 @@ kubetl get pods -l kritis.grafeas.io/invalidImageSecPolicy=invalidImageSecPolicy
 
 GenericAttestationPolicy (GAP) is a Custom Resource Definition which enforces policies based on pre-existing attestations.
 The policy expects ALL attestation authorities to be satisfied before allowing the container image to be admitted.
-If no attestation authority is present in GAP, the container image will be admitted automatically.
 As opposed to [ISPs](#imagesecuritypolicy-crd) the GAP does not create new attestations.
 The general use case for GAPs are to have a policy that enforces attestations that have come from your CI pipeline, or other places in your release pipeline.
 
@@ -85,7 +84,9 @@ Generic Attestation Policy Spec description:
 
 | Field     | Default (if applicable)   | Description |
 |-----------|---------------------------|-------------|
-| attestationAuthorityNames | | List of [Attestation Authorities](#attestationauthority-crd) for which one of is required to be satisfied before the Admission Controller will admit the pod.|
+| attestationAuthorityNames | | Non-empty List of [Attestation Authorities](#attestationauthority-crd) for which all of them are required to be satisfied before the Admission Controller will admit the pod.|
+
+Note that the list of [Attestation Authorities](#attestationauthority-crd) must be non-empty. If the list is empty, images can only be admitted through allowlist (GAP allowlist is WIP).
 
 ## ImageSecurityPolicy CRD
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -35,7 +35,8 @@ kubetl get pods -l kritis.grafeas.io/invalidImageSecPolicy=invalidImageSecPolicy
 ## GenericAttestationPolicy CRD
 
 GenericAttestationPolicy (GAP) is a Custom Resource Definition which enforces policies based on pre-existing attestations.
-The policy expects any one attestation authority to be satisfied before allowing the container image to be admitted.
+The policy expects ALL attestation authorities to be satisfied before allowing the container image to be admitted.
+If no attestation authority is present in GAP, the container image will be admitted automatically.
 As opposed to [ISPs](#imagesecuritypolicy-crd) the GAP does not create new attestations.
 The general use case for GAPs are to have a policy that enforces attestations that have come from your CI pipeline, or other places in your release pipeline.
 

--- a/pkg/kritis/review/review.go
+++ b/pkg/kritis/review/review.go
@@ -61,8 +61,8 @@ func generateGapAllowlist(gaps []v1beta1.GenericAttestationPolicy) []string {
 	return allowlist
 }
 
-// ReviewImageWithGAP reviews single image against a single generic attestation policy
-func (r Reviewer) ReviewImageWithGAP(image string, gap v1beta1.GenericAttestationPolicy, c metadata.ReadOnlyClient) (bool, []string, error) {
+// reviewImageWithGAP reviews single image against a single generic attestation policy
+func (r Reviewer) reviewImageWithGAP(image string, gap v1beta1.GenericAttestationPolicy, c metadata.ReadOnlyClient) (bool, []string, error) {
 	glog.Infof("Validating against GenericAttestationPolicy %s", gap.Name)
 
 	// Get all AttestationAuthorities in this policy.
@@ -128,7 +128,7 @@ func (r Reviewer) ReviewGAP(images []string, gaps []v1beta1.GenericAttestationPo
 		imgAttestedByAnyGap := false
 		missingAttestations[image] = map[string][]string{}
 		for _, gap := range gaps {
-			isAttested, notAttestedAuthNames, err := r.ReviewImageWithGAP(image, gap, c)
+			isAttested, notAttestedAuthNames, err := r.reviewImageWithGAP(image, gap, c)
 			if err != nil {
 				return err
 			}

--- a/pkg/kritis/review/review_test.go
+++ b/pkg/kritis/review/review_test.go
@@ -111,6 +111,9 @@ func TestReviewGAP(t *testing.T) {
 			Namespace: "foo",
 		},
 		Spec: v1beta1.GenericAttestationPolicySpec{
+			AdmissionAllowlistPatterns: []v1beta1.AdmissionAllowlistPatternSpec{
+				{NamePattern: "allowed_image_name"},
+			},
 			AttestationAuthorityNames: []string{},
 		},
 	}}
@@ -166,6 +169,14 @@ func TestReviewGAP(t *testing.T) {
 		{
 			name:         "gap without attestor should error",
 			image:        img,
+			policies:     gapWithoutAA,
+			attestations: []metadata.PGPAttestation{},
+			isAdmitted:   false,
+			shouldErr:    true,
+		},
+		{
+			name:         "gap without attestor should error on allowlisted image",
+			image:        "allowed_image_name",
 			policies:     gapWithoutAA,
 			attestations: []metadata.PGPAttestation{},
 			isAdmitted:   false,

--- a/pkg/kritis/review/review_test.go
+++ b/pkg/kritis/review/review_test.go
@@ -56,7 +56,7 @@ func TestReviewGAP(t *testing.T) {
 		}
 		return nil, fmt.Errorf("Not such secret for %s", name)
 	}
-	validAtts := []metadata.PGPAttestation{{Signature: encodeB64(sig), KeyID: secFpr}}
+	oneValidAtt := []metadata.PGPAttestation{{Signature: encodeB64(sig), KeyID: secFpr}}
 	twoValidAtts := []metadata.PGPAttestation{
 		{Signature: encodeB64(sig), KeyID: secFpr},
 		{Signature: encodeB64(sig2), KeyID: secFpr2},
@@ -94,9 +94,7 @@ func TestReviewGAP(t *testing.T) {
 			},
 		},
 	}
-	// One policy with two attestors:
-	// 'test' -- satisfies QualifiedImage
-	// 'test2' -- does not satisfy any image in this test
+	// One policy with two attestors.
 	gapWithTwoAAs := []v1beta1.GenericAttestationPolicy{{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
@@ -105,7 +103,7 @@ func TestReviewGAP(t *testing.T) {
 			AttestationAuthorityNames: []string{"test", "test2"},
 		},
 	}}
-	// One policy without attestor:
+	// One policy without attestor.
 	gapWithoutAA := []v1beta1.GenericAttestationPolicy{{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
@@ -154,7 +152,7 @@ func TestReviewGAP(t *testing.T) {
 			name:         "valid image with attestation",
 			image:        img,
 			policies:     oneGAP,
-			attestations: validAtts,
+			attestations: oneValidAtt,
 			isAdmitted:   true,
 			shouldErr:    false,
 		},
@@ -218,7 +216,7 @@ func TestReviewGAP(t *testing.T) {
 			name:         "image complies with one policy out of two",
 			image:        img,
 			policies:     twoGAPs,
-			attestations: validAtts,
+			attestations: oneValidAtt,
 			isAdmitted:   true,
 			shouldErr:    false,
 		},
@@ -234,7 +232,7 @@ func TestReviewGAP(t *testing.T) {
 			name:         "image attested by one attestor out of two",
 			image:        img,
 			policies:     gapWithTwoAAs,
-			attestations: validAtts,
+			attestations: oneValidAtt,
 			isAdmitted:   false,
 			shouldErr:    true,
 		},


### PR DESCRIPTION
This PR will change Kritis Generic Attestation Policy (GAP) semantic to “all attestors”. Currently the semantic is ANY for the purpose of key rotation, which will be addressed by the previous proposed change (supporting multiple keys in Kritis attestor).  

Also edge case: if a GAP has no attestor, the image will still be admitted.

If there are multiple GAPs, only one GAP needs to be satisfied for image to be admitted.

The change  is in part to get compatibility with Binary Authorization.
