### PR TITLE
Add test for paginating through Container Analysis vulnerabilities

### DIFF
--- a/pkg/kritis/metadata/containeranalysis/containeranalysis.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis.go
@@ -121,7 +121,6 @@ func (c Client) fetchVulnerabilityOccurrence(containerImage string, kind string)
 	}
 
 	req := createListOccurrencesRequest(containerImage, kind)
-	fmt.Println(req)
 
 	it := c.client.ListOccurrences(c.ctx, req)
 	p := iterator.NewPager(it, int(req.PageSize), "")

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis.go
@@ -146,7 +146,7 @@ func (c Client) fetchAttestationOccurrence(containerImage string, kind string, a
 	req := &grafeas.ListNoteOccurrencesRequest{
 		Name: auth.Spec.NoteReference,
 		// Example:
-		//              Filter:  fmt.Sprintf("resourceUrl=%q AND kind=%q", util.GetResourceURL(containerImage), kind),
+		// 		Filter:  fmt.Sprintf("resourceUrl=%q AND kind=%q", util.GetResourceURL(containerImage), kind),
 		Filter:   fmt.Sprintf("resourceUrl=%q", util.GetResourceURL(containerImage)),
 		PageSize: constants.PageSize,
 	}

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis.go
@@ -123,16 +123,16 @@ func (c Client) fetchVulnerabilityOccurrence(containerImage string, kind string)
 	req := createListOccurrencesRequest(containerImage, kind)
 
 	it := c.client.ListOccurrences(c.ctx, req)
-	p := iterator.NewPager(it, int(req.PageSize), "")
 	occs := []*grafeas.Occurrence{}
 	for {
-		nextPageToken, err := p.NextPage(&occs)
+		occ, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
 		if err != nil {
 			return nil, err
 		}
-		if nextPageToken == "" {
-			break
-		}
+		occs = append(occs, occ)
 	}
 	return occs, nil
 }

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
@@ -156,7 +156,7 @@ func TestGetMultiplePagesVulnerabilities(t *testing.T) {
 	}
 
 	if len(vuln) <= 900 {
-		t.Fatalf("Pagination error: expected at least 900 results on image 'gcr.io/kritis-int-test/java-with-vulnz'. Received %client.", len(vuln))
+		t.Fatalf("Pagination error: expected at least 900 results on image 'gcr.io/kritis-int-test/java-with-vulnz'. Received %d.", len(vuln))
 	}
 }
 

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
@@ -141,7 +141,7 @@ func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
 	}
 }
 
-func TestGetMultiplePages_Vulnerabilities(t *testing.T) {
+func TestGetMultiplePagesVulnerabilities(t *testing.T) {
 	d, err := New()
 	if err != nil {
 		t.Fatalf("Could not initialize the client %s", err)
@@ -156,7 +156,7 @@ func TestGetMultiplePages_Vulnerabilities(t *testing.T) {
 	}
 
 	if len(vuln) <= 900 {
-		t.Errorf("Pagination error: did not receive results from the final page.")
+		t.Fatalf("Pagination error: expected at least 900 results on image 'gcr.io/kritis-int-test/java-with-vulnz'. Received %d.", len(vuln))
 	}
 }
 

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
@@ -148,7 +148,7 @@ func TestGetMultiplePages_Vulnerabilities(t *testing.T) {
 	}
 
 	// Set PageSize to 300
-	createListOccurrencesRequest = createListOccurrencesRequest_test
+	createListOccurrencesRequest = createListOccurrencesRequestTest
 
 	vuln, err := d.Vulnerabilities("gcr.io/kritis-int-test/java-with-vulnz@sha256:358687cfd3ec8e1dfeb2bf51b5110e4e16f6df71f64fba01986f720b2fcba68a")
 	if err != nil {
@@ -160,7 +160,7 @@ func TestGetMultiplePages_Vulnerabilities(t *testing.T) {
 	}
 }
 
-func createListOccurrencesRequest_test(containerImage, kind string) *grafeas.ListOccurrencesRequest {
+func createListOccurrencesRequestTest(containerImage, kind string) *grafeas.ListOccurrencesRequest {
 	return &grafeas.ListOccurrencesRequest{
 		Filter:   fmt.Sprintf("resourceUrl=%q AND kind=%q", util.GetResourceURL(containerImage), kind),
 		Parent:   fmt.Sprintf("projects/%s", getProjectFromContainerImage(containerImage)),

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
@@ -50,11 +50,11 @@ func GetAA() *kritisv1beta1.AttestationAuthority {
 }
 
 func TestGetVulnerabilities(t *testing.T) {
-	d, err := New()
+	client, err := New()
 	if err != nil {
 		t.Fatalf("Could not initialize the client %s", err)
 	}
-	vuln, err := d.Vulnerabilities("gcr.io/kritis-int-test/java-with-vulnz@sha256:358687cfd3ec8e1dfeb2bf51b5110e4e16f6df71f64fba01986f720b2fcba68a")
+	vuln, err := client.Vulnerabilities("gcr.io/kritis-int-test/java-with-vulnz@sha256:358687cfd3ec8e1dfeb2bf51b5110e4e16f6df71f64fba01986f720b2fcba68a")
 	if err != nil {
 		t.Fatalf("Found err %s", err)
 	}
@@ -64,18 +64,18 @@ func TestGetVulnerabilities(t *testing.T) {
 }
 
 func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
-	d, err := New()
+	client, err := New()
 	if err != nil {
 		t.Fatalf("Could not initialize the client %s", err)
 	}
 	aa := GetAA()
-	_, err = d.CreateAttestationNote(aa)
+	_, err = client.CreateAttestationNote(aa)
 	if err != nil {
 		t.Fatalf("Unexpected error while creating Note %v", err)
 	}
-	defer d.DeleteAttestationNote(aa)
+	defer client.DeleteAttestationNote(aa)
 
-	note, err := d.AttestationNote(aa)
+	note, err := client.AttestationNote(aa)
 	if err != nil {
 		t.Fatalf("Unexpected no error while getting attestation note %v", err)
 	}
@@ -105,7 +105,7 @@ func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to extract project ID %v", err)
 	}
-	occ, err := d.CreateAttestationOccurrence(note, testutil.IntTestImage, secret, proj)
+	occ, err := client.CreateAttestationOccurrence(note, testutil.IntTestImage, secret, proj)
 	if err != nil {
 		t.Fatalf("Unexpected error while creating Occurence %v", err)
 	}
@@ -117,7 +117,7 @@ func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
 	if pgpKeyID != expectedPgpKeyID {
 		t.Errorf("Expected PGP key id: %q, got %q", expectedPgpKeyID, pgpKeyID)
 	}
-	defer d.DeleteOccurrence(occ.GetName())
+	defer client.DeleteOccurrence(occ.GetName())
 
 	// Keep trying to list attestation occurrences until we time out.
 	// Because the staleness bound is on the order of seconds, no need to try faster than once a second.
@@ -131,7 +131,7 @@ func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
 
 			// Got a tick, we should check note occurrences
 		case <-tick:
-			if occurrences, err := d.Attestations(testutil.IntTestImage, aa); err != nil {
+			if occurrences, err := client.Attestations(testutil.IntTestImage, aa); err != nil {
 				t.Fatalf("Failed to retrieve attestations: %v", err)
 			} else if len(occurrences) > 0 {
 				// Successfully retrieved attestations, exit the loop and the test.
@@ -142,7 +142,7 @@ func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
 }
 
 func TestGetMultiplePagesVulnerabilities(t *testing.T) {
-	d, err := New()
+	client, err := New()
 	if err != nil {
 		t.Fatalf("Could not initialize the client %s", err)
 	}
@@ -150,13 +150,13 @@ func TestGetMultiplePagesVulnerabilities(t *testing.T) {
 	// Set PageSize to 300
 	createListOccurrencesRequest = createListOccurrencesRequestTest
 
-	vuln, err := d.Vulnerabilities("gcr.io/kritis-int-test/java-with-vulnz@sha256:358687cfd3ec8e1dfeb2bf51b5110e4e16f6df71f64fba01986f720b2fcba68a")
+	vuln, err := client.Vulnerabilities("gcr.io/kritis-int-test/java-with-vulnz@sha256:358687cfd3ec8e1dfeb2bf51b5110e4e16f6df71f64fba01986f720b2fcba68a")
 	if err != nil {
 		t.Fatalf("Found err %s", err)
 	}
 
 	if len(vuln) <= 900 {
-		t.Fatalf("Pagination error: expected at least 900 results on image 'gcr.io/kritis-int-test/java-with-vulnz'. Received %d.", len(vuln))
+		t.Fatalf("Pagination error: expected at least 900 results on image 'gcr.io/kritis-int-test/java-with-vulnz'. Received %client.", len(vuln))
 	}
 }
 

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
@@ -129,7 +129,7 @@ func TestCreateAttestationNoteAndOccurrence(t *testing.T) {
 		case <-timeout:
 			t.Fatal("Should have created at least 1 occurrence")
 
-		// Got a tick, we should check note occurrences
+			// Got a tick, we should check note occurrences
 		case <-tick:
 			if occurrences, err := d.Attestations(testutil.IntTestImage, aa); err != nil {
 				t.Fatalf("Failed to retrieve attestations: %v", err)

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
@@ -160,7 +160,6 @@ func TestGetMultiplePages_Vulnerabilities(t *testing.T) {
 	}
 }
 
-// TODO: Remove this function if we use the same PageSize -- it would be redundant
 func createListOccurrencesRequest_test(containerImage, kind string) *grafeas.ListOccurrencesRequest {
 	return &grafeas.ListOccurrencesRequest{
 		Filter:   fmt.Sprintf("resourceUrl=%q AND kind=%q", util.GetResourceURL(containerImage), kind),

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
@@ -147,7 +147,7 @@ func TestGetMultiplePagesVulnerabilities(t *testing.T) {
 		t.Fatalf("Could not initialize the client %s", err)
 	}
 
-	// Set PageSize to 300
+	// Set PageSize to 100
 	createListOccurrencesRequest = createListOccurrencesRequestTest
 
 	vuln, err := client.Vulnerabilities("gcr.io/kritis-int-test/java-with-vulnz@sha256:358687cfd3ec8e1dfeb2bf51b5110e4e16f6df71f64fba01986f720b2fcba68a")

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_int_test.go
@@ -155,8 +155,8 @@ func TestGetMultiplePages_Vulnerabilities(t *testing.T) {
 		t.Fatalf("Found err %s", err)
 	}
 
-	if len(vuln) <= 300 {
-		t.Errorf("Pagination error: only received results from first page.")
+	if len(vuln) <= 900 {
+		t.Errorf("Pagination error: did not receive results from the final page.")
 	}
 }
 
@@ -164,6 +164,6 @@ func createListOccurrencesRequestTest(containerImage, kind string) *grafeas.List
 	return &grafeas.ListOccurrencesRequest{
 		Filter:   fmt.Sprintf("resourceUrl=%q AND kind=%q", util.GetResourceURL(containerImage), kind),
 		Parent:   fmt.Sprintf("projects/%s", getProjectFromContainerImage(containerImage)),
-		PageSize: int32(300),
+		PageSize: int32(100),
 	}
 }


### PR DESCRIPTION
API calls to Container Analysis and Grafeas involve pagination when extracting Vulnerabilities and Attestations. This change ensures that calls made to Container Analysis to extract Vulnerabilities properly iterate through all pages.

TESTED= new integration test
ISSUE= #419 