### PR TITLE
Update install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -176,7 +176,7 @@ For more information, please see the resolve-tags [documentation](cmd/kritis/kub
 Install kritis to your cluster:
 
 ```shell
-helm install https://storage.googleapis.com/kritis-charts/repository/kritis-charts-0.1.0.tgz
+helm install https://storage.googleapis.com/kritis-charts/repository/kritis-charts-0.2.2.tgz
 ```
 
 You may use the --set flag, to override the installation defaults:


### PR DESCRIPTION
Older version of kritis charts causes issue while installation and after executing with kritis-chart 0.2.1 it was working all good.
Since amended the changes to point latest helm charts.