### PR TITLE
Fix cron integration test -- wait for pods to delete between testcases

### DIFF
--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -92,7 +92,7 @@ func cleanupTemplate(t *testing.T, path, ns string) error {
 		return fmt.Errorf("kubectl delete failed: %v\nout: %s", err, out)
 	}
 
-	cmd = exec.Command("kubectl", "wait", "--for=delete")
+	cmd = exec.Command("kubectl", "wait", "--for=delete", "--timeout=3m")
 	if out, err := integration_util.RunCmdOut(cmd); err != nil {
 		t.Fatalf("kubectl wait failed: %v\nout: %s", err, out)
 	}

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -84,13 +84,17 @@ func cleanupTemplate(t *testing.T, path, ns string) error {
 		return nil
 	}
 	t.Logf("Cleaning up after %s ...", path)
-	cmd := exec.Command("kubectl", "delete", "-f", path, "--namespace", ns)
-	output, err := integration_util.RunCmdOut(cmd)
-	if err != nil {
-		return fmt.Errorf("kubectl delete failed: %s %v", output, err)
-	}
 	if err := os.Remove(path); err != nil {
 		return fmt.Errorf("remove failed: %v", err)
+	}
+	cmd := exec.Command("kubectl", "delete", "-f", path, "--namespace", ns)
+	out, err := integration_util.RunCmdOut(cmd)
+	if err != nil {
+		return fmt.Errorf("kubectl delete failed: %s %v", out, err)
+	}
+	cmd = exec.Command("kubectl", "wait", "--for=delete")
+	if out, err := integration_util.RunCmdOut(cmd); err != nil {
+		t.Fatalf("testing error: %v\nout: %s", err, out)
 	}
 	return nil
 }

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -88,13 +88,12 @@ func cleanupTemplate(t *testing.T, path, ns string) error {
 		return fmt.Errorf("remove failed: %v", err)
 	}
 	cmd := exec.Command("kubectl", "delete", "-f", path, "--namespace", ns)
-	out, err := integration_util.RunCmdOut(cmd)
-	if err != nil {
-		return fmt.Errorf("kubectl delete failed: %s %v", out, err)
+	if out, err := integration_util.RunCmdOut(cmd); err != nil {
+		return fmt.Errorf("kubectl delete failed: %v\nout: %s", err, out)
 	}
 	cmd = exec.Command("kubectl", "wait", "--for=delete")
 	if out, err := integration_util.RunCmdOut(cmd); err != nil {
-		t.Fatalf("testing error: %v\nout: %s", err, out)
+		t.Fatalf("kubectl wait failed: %v\nout: %s", err, out)
 	}
 	return nil
 }

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -91,6 +91,7 @@ func cleanupTemplate(t *testing.T, path, ns string) error {
 	if out, err := integration_util.RunCmdOut(cmd); err != nil {
 		return fmt.Errorf("kubectl delete failed: %v\nout: %s", err, out)
 	}
+
 	cmd = exec.Command("kubectl", "wait", "--for=delete")
 	if out, err := integration_util.RunCmdOut(cmd); err != nil {
 		t.Fatalf("kubectl wait failed: %v\nout: %s", err, out)


### PR DESCRIPTION
`TestKritisCron` was failing because it was not waiting for pods to terminate between testcases. Introduced a `kubectl wait` command between testcases.