### PR TITLE
fix the cleanup logic so that it does not panic if namespace is nil

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ clean:
 integration-prod: cross
 	go test -ldflags "$(GO_LDFLAGS)" -v -tags integration \
 		$(REPOPATH)/integration \
-		-timeout 60m \
+		-timeout 15m \
 		-gac-credentials=/tmp/gac.json \
 		-gcp-project=kritis-int-test \
 		-gke-cluster-name=test-cluster-2 $(EXTRA_TEST_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ clean:
 integration-prod: cross
 	go test -ldflags "$(GO_LDFLAGS)" -v -tags integration \
 		$(REPOPATH)/integration \
-		-timeout 15m \
+		-timeout 60m \
 		-gac-credentials=/tmp/gac.json \
 		-gcp-project=kritis-int-test \
 		-gke-cluster-name=test-cluster-2 $(EXTRA_TEST_FLAGS)

--- a/integration/cleanup.go
+++ b/integration/cleanup.go
@@ -47,10 +47,16 @@ func deleteObject(object, name string, ns *v1.Namespace) error {
 	deleteCmd := exec.Command("kubectl", "delete", object, name)
 	if ns != nil {
 		deleteCmd.Args = append(deleteCmd.Args, []string{"-n", ns.Name}...)
-	}
-	_, err := integration_util.RunCmdOut(deleteCmd)
-	if err != nil {
-		return fmt.Errorf("error deleting %s %s in namespace %s: %v", object, name, ns.Name, err)
+
+		_, err := integration_util.RunCmdOut(deleteCmd)
+		if err != nil {
+			return fmt.Errorf("error deleting %s %s in namespace %s: %v", object, name, ns.Name, err)
+		}
+	} else {
+		_, err := integration_util.RunCmdOut(deleteCmd)
+		if err != nil {
+			return fmt.Errorf("error deleting %s %s: %v", object, name, err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
prior to the change, I observed this error which is related to the nil ptr dereferencing. 

panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x10b139b]

goroutine 104 [running]:
testing.tRunner.func1(0xc000365000)
	/usr/local/go/src/testing/testing.go:830 +0x392
panic(0x11e8540, 0x2085870)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
github.com/grafeas/kritis/integration.deleteObject(0x1379ca7, 0x1e, 0xc00058e360, 0x1f, 0x0, 0xc00058e380, 0x20)
	/go/src/github.com/grafeas/kritis/integration/cleanup.go:53 +0x27b
github.com/grafeas/kritis/integration.cleanupInstall(0xc00068a140, 0x13836c6, 0x26)
	/go/src/github.com/grafeas/kritis/integration/cleanup.go:39 +0x314
github.com/grafeas/kritis/integration.installKritis.func1(0xc000365000)
	/go/src/github.com/grafeas/kritis/integration/run_test.go:205 +0x4ed
github.com/grafeas/kritis/integration.setUpKritisInNS.func1(0xc000365000)
	/go/src/github.com/grafeas/kritis/integration/run_test.go:282 +0x38
github.com/grafeas/kritis/integration.setUpISP.func1(0xc000365000)
	/go/src/github.com/grafeas/kritis/integration/run_test.go:321 +0x73

github.com/grafeas/kritis/integration.TestKritisISPLogic(0xc000365000)
	/go/src/github.com/grafeas/kritis/integration/run_test.go:567 +0x713
testing.tRunner(0xc000365000, 0x13eb560)
	/usr/local/go/src/testing/testing.go:865 +0xc0
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:916 +0x35a
FAIL	github.com/grafeas/kritis/integration	968.278s
make: *** [integration-prod] Error 1
Makefile:136: recipe for target 'integration-prod' failed