### PR TITLE
[ISSUE-506] Remove unnecessary error check

### DIFF
--- a/pkg/kritis/review/validating_transport.go
+++ b/pkg/kritis/review/validating_transport.go
@@ -143,10 +143,6 @@ func (avt *AttestorValidatingTransport) fetchAttestations(image string) ([]*cryp
 		if rawAtt.SignatureType != metadata.PgpSignatureType {
 			return nil, fmt.Errorf("Signature type %s is not supported for Attestation %v", rawAtt.SignatureType.String(), rawAtt)
 		}
-		if err != nil {
-			glog.Warningf("Cannot base64 decode signature for attestation %v. Error: %v", rawAtt, err)
-			continue
-		}
 		// TODO(https://github.com/grafeas/kritis/issues/505): Remove this
 		// after Kritis migrates to cryptolib.Attestation.
 		att := &cryptolib.Attestation{


### PR DESCRIPTION
Leftover from https://github.com/grafeas/kritis/pull/511. Also see the discussion [here](https://github.com/grafeas/kritis/pull/514#issuecomment-631677556).

Disclaimer: I was not able to test this locally now, but reading the code and the aforementioned PR, I believe this change is correct.