### PR TITLE
Use EffectiveSeverity instead of Severity in vulnerability details.

### DIFF
--- a/pkg/kritis/metadata/metadata.go
+++ b/pkg/kritis/metadata/metadata.go
@@ -102,7 +102,7 @@ func GetVulnerabilityFromOccurrence(occ *grafeas.Occurrence) *Vulnerability {
 	}
 	hasFixAvailable := IsFixAvailable(vulnDetails.GetPackageIssue())
 	vulnerability := Vulnerability{
-		Severity:        vulnerability.Severity_name[int32(vulnDetails.Severity)],
+		Severity:        vulnerability.Severity_name[int32(vulnDetails.EffectiveSeverity)],
 		HasFixAvailable: hasFixAvailable,
 		CVE:             occ.GetNoteName(),
 	}

--- a/pkg/kritis/metadata/metadata_test.go
+++ b/pkg/kritis/metadata/metadata_test.go
@@ -66,7 +66,7 @@ func TestGetVulnerabilityFromOccurence(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			vulnDetails := &grafeas.Occurrence_Vulnerability{
 				Vulnerability: &vulnerability.Details{
-					Severity: tc.severity,
+					EffectiveSeverity: tc.severity,
 					PackageIssue: []*vulnerability.PackageIssue{
 						{
 							AffectedLocation: &vulnerability.VulnerabilityLocation{},


### PR DESCRIPTION
We should consider using the `EffectiveSeverity` field instead of `Severity` in Container Analysis's vulnerability occurrence. 
From Container Analysis Vulnerability Scanning [doc](https://cloud.google.com/container-registry/docs/vulnerability-scanning):
```
Effective severity - The severity level assigned by the Linux distribution. If distribution-specific severity levels are unavailable, Container Analysis uses the severity level assigned by the note provider.
```
`EffectiveSeverity` is also what's displayed as `Severity` on Container Analysis UI. 