### PR TITLE
Delete crypto functionality in AtomicContainerSig

### DIFF
--- a/pkg/kritis/container/container.go
+++ b/pkg/kritis/container/container.go
@@ -17,16 +17,10 @@ limitations under the License.
 package container
 
 import (
-	"encoding/base64"
 	"encoding/json"
-	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
-	"github.com/grafeas/kritis/pkg/kritis/attestation"
 	"github.com/grafeas/kritis/pkg/kritis/constants"
-	"github.com/grafeas/kritis/pkg/kritis/secrets"
-	"github.com/pkg/errors"
 )
 
 // for testing
@@ -107,46 +101,4 @@ func (acs *AtomicContainerSig) JSON() (string, error) {
 		return "", err
 	}
 	return string(bytes), nil
-}
-
-func (acs *AtomicContainerSig) CreateAttestationSignature(pgpSigningKey *secrets.PGPSigningSecret) (string, error) {
-	hostStr, err := acs.JSON()
-	if err != nil {
-		return "", err
-	}
-	return attestation.CreateMessageAttestation(pgpSigningKey.PgpKey, hostStr)
-}
-
-func (acs *AtomicContainerSig) VerifySignature(publicKey v1beta1.PublicKey, sig string) error {
-	switch publicKey.KeyType {
-	case v1beta1.PgpKeyType:
-		decodedKey, err := base64.StdEncoding.DecodeString(publicKey.AsciiArmoredPgpPublicKey)
-		if err != nil {
-			return err
-		}
-		return acs.VerifyPgpSignature(string(decodedKey), sig)
-	case v1beta1.PkixKeyType:
-	default:
-		return fmt.Errorf("Unsupported key type: %s", publicKey.KeyType)
-	}
-	return nil
-}
-
-func (acs *AtomicContainerSig) VerifyPgpSignature(publicKey string, sig string) error {
-	hostSig, err := attestation.GetPlainMessage(publicKey, sig)
-	if err != nil {
-		return errors.Wrap(err, "error verifying signature")
-	}
-	// Unmarshall the json host string to get AtomicContainerSig struct
-	var host AtomicContainerSig
-	if err := json.Unmarshal(hostSig, &host); err != nil {
-		return errors.Wrap(err, "error unmarshaling json")
-	}
-
-	if !host.Equals(acs) {
-		h1, _ := host.JSON()
-		h2, _ := acs.JSON()
-		return fmt.Errorf("sig not verified. Expected %s, Got %s", h1, h2)
-	}
-	return nil
 }

--- a/pkg/kritis/container/container_test.go
+++ b/pkg/kritis/container/container_test.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/grafeas/kritis/pkg/kritis/secrets"
 	"github.com/grafeas/kritis/pkg/kritis/testutil"
 )
 
@@ -71,83 +70,6 @@ func Test_ContainerSigCreation(t *testing.T) {
 				t.Errorf("\nExpected\n%+v\nActual\n%+v", expected.Critical, actual.Critical)
 			}
 		})
-	}
-}
-
-func TestCreateAttestationSignature(t *testing.T) {
-	container, err := NewAtomicContainerSig(goodImage, map[string]string{})
-	if err != nil {
-		t.Fatalf("Unexpected error %s", err)
-	}
-	secret, _ := testutil.CreateSecret(t, "test")
-	tests := []struct {
-		name          string
-		signingSecret *secrets.PGPSigningSecret
-		shouldErr     bool
-	}{
-		{
-			name:          "Good secret",
-			shouldErr:     false,
-			signingSecret: secret,
-		},
-		{
-			name:          "bad secret",
-			shouldErr:     false,
-			signingSecret: nil,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			_, err := container.CreateAttestationSignature(secret)
-			testutil.CheckError(t, test.shouldErr, err)
-		})
-	}
-}
-
-func TestValidateAttestationSignature(t *testing.T) {
-	secret, pub := testutil.CreateSecret(t, "test")
-	container, err := NewAtomicContainerSig(goodImage, map[string]string{})
-	if err != nil {
-		t.Fatalf("Unexpected error %s", err)
-	}
-	inputSig, err := container.CreateAttestationSignature(secret)
-	if err != nil {
-		t.Fatalf("Unexpected error %s", err)
-	}
-
-	tests := []struct {
-		name      string
-		shouldErr bool
-		publickey string
-	}{
-		{
-			name:      "verify using same public key",
-			shouldErr: false,
-			publickey: pub,
-		},
-		{
-			name:      "verify using another public key",
-			shouldErr: true,
-			publickey: testutil.PublicTestKey,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			verificationErr := container.VerifyPgpSignature(test.publickey, inputSig)
-			testutil.CheckError(t, test.shouldErr, verificationErr)
-		})
-	}
-}
-
-func TestGPGArmorSignVerifyIntegration(t *testing.T) {
-	container, err := NewAtomicContainerSig(goodImage, map[string]string{})
-	if err != nil {
-		t.Fatalf("Unexpected error %s", err)
-	}
-	if err := container.VerifyPgpSignature(testutil.Base64PublicTestKey(t), expectedSig); err != nil {
-		t.Fatalf("unexpected error %s", err)
 	}
 }
 


### PR DESCRIPTION
`AtomicContainerSig` was used to create and verify PGP-signed attestations and check the contents of the attestation payload. Kritis has migrated to `cryptolib` for these operations, so this functionality is unused and unnecessary.