### PR TITLE
Delete verification operations in attestation package

### DIFF
--- a/pkg/kritis/attestation/attestation_test.go
+++ b/pkg/kritis/attestation/attestation_test.go
@@ -16,13 +16,6 @@ limitations under the License.
 
 package attestation
 
-import (
-	"testing"
-
-	"github.com/grafeas/kritis/pkg/kritis/secrets"
-	"github.com/grafeas/kritis/pkg/kritis/testutil"
-)
-
 var tcAttestations = []struct {
 	name      string
 	message   string
@@ -32,33 +25,6 @@ var tcAttestations = []struct {
 	{"test-success", "test", "", false},
 	{"test-invalid-sig", "test", invalidSig, true},
 	{"test-incorrect-sig", "test", incorrectSig, true},
-}
-
-func TestAttestations(t *testing.T) {
-	for _, tc := range tcAttestations {
-		publicKey, privateKey := testutil.CreateKeyPair(t, "test")
-		pgpKey, err := secrets.NewPgpKey(privateKey, "", publicKey)
-		if err != nil {
-			t.Fatalf("Unexpected error %s", err)
-		}
-		t.Run(tc.name, func(t *testing.T) {
-			sig, err := CreateMessageAttestation(pgpKey, tc.message)
-			if err != nil {
-				t.Fatalf("Unexpected error %s", err)
-			}
-			if tc.signature == "" {
-				tc.signature = sig
-			}
-			err = VerifyMessageAttestation(publicKey, tc.signature, tc.message)
-			testutil.CheckError(t, tc.hasErr, err)
-		})
-	}
-}
-
-func TestGPGArmorSignIntegration(t *testing.T) {
-	if err := VerifyMessageAttestation(testutil.Base64PublicTestKey(t), expectedSig, "test"); err != nil {
-		t.Fatalf("unexpected error %s", err)
-	}
 }
 
 //  signature.

--- a/pkg/kritis/container/container.go
+++ b/pkg/kritis/container/container.go
@@ -17,16 +17,10 @@ limitations under the License.
 package container
 
 import (
-	"encoding/base64"
 	"encoding/json"
-	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
-	"github.com/grafeas/kritis/pkg/kritis/attestation"
 	"github.com/grafeas/kritis/pkg/kritis/constants"
-	"github.com/grafeas/kritis/pkg/kritis/secrets"
-	"github.com/pkg/errors"
 )
 
 // for testing
@@ -107,46 +101,4 @@ func (acs *AtomicContainerSig) JSON() (string, error) {
 		return "", err
 	}
 	return string(bytes), nil
-}
-
-func (acs *AtomicContainerSig) CreateAttestationSignature(pgpSigningKey *secrets.PGPSigningSecret) (string, error) {
-	hostStr, err := acs.JSON()
-	if err != nil {
-		return "", err
-	}
-	return attestation.CreateMessageAttestation(pgpSigningKey.PgpKey, hostStr)
-}
-
-func (acs *AtomicContainerSig) VerifySignature(publicKey v1beta1.PublicKey, sig string) error {
-	switch publicKey.KeyType {
-	case v1beta1.PgpKeyType:
-		decodedKey, err := base64.StdEncoding.DecodeString(publicKey.AsciiArmoredPgpPublicKey)
-		if err != nil {
-			return err
-		}
-		return acs.VerifyPgpSignature(string(decodedKey), sig)
-	case v1beta1.PkixKeyType:
-	default:
-		return fmt.Errorf("Unsupported key type: %s", publicKey.KeyType)
-	}
-	return nil
-}
-
-func (acs *AtomicContainerSig) VerifyPgpSignature(publicKey string, sig string) error {
-	hostSig, err := attestation.GetPlainMessage(publicKey, sig)
-	if err != nil {
-		return errors.Wrap(err, "error verifying signature")
-	}
-	// Unmarshall the json host string to get AtomicContainerSig struct
-	var host AtomicContainerSig
-	if err := json.Unmarshal(hostSig, &host); err != nil {
-		return errors.Wrap(err, "error unmarshaling json")
-	}
-
-	if !host.Equals(acs) {
-		h1, _ := host.JSON()
-		h2, _ := acs.JSON()
-		return fmt.Errorf("sig not verified. Expected %s, Got %s", h1, h2)
-	}
-	return nil
 }

--- a/pkg/kritis/container/container_test.go
+++ b/pkg/kritis/container/container_test.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/grafeas/kritis/pkg/kritis/secrets"
 	"github.com/grafeas/kritis/pkg/kritis/testutil"
 )
 
@@ -71,83 +70,6 @@ func Test_ContainerSigCreation(t *testing.T) {
 				t.Errorf("\nExpected\n%+v\nActual\n%+v", expected.Critical, actual.Critical)
 			}
 		})
-	}
-}
-
-func TestCreateAttestationSignature(t *testing.T) {
-	container, err := NewAtomicContainerSig(goodImage, map[string]string{})
-	if err != nil {
-		t.Fatalf("Unexpected error %s", err)
-	}
-	secret, _ := testutil.CreateSecret(t, "test")
-	tests := []struct {
-		name          string
-		signingSecret *secrets.PGPSigningSecret
-		shouldErr     bool
-	}{
-		{
-			name:          "Good secret",
-			shouldErr:     false,
-			signingSecret: secret,
-		},
-		{
-			name:          "bad secret",
-			shouldErr:     false,
-			signingSecret: nil,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			_, err := container.CreateAttestationSignature(secret)
-			testutil.CheckError(t, test.shouldErr, err)
-		})
-	}
-}
-
-func TestValidateAttestationSignature(t *testing.T) {
-	secret, pub := testutil.CreateSecret(t, "test")
-	container, err := NewAtomicContainerSig(goodImage, map[string]string{})
-	if err != nil {
-		t.Fatalf("Unexpected error %s", err)
-	}
-	inputSig, err := container.CreateAttestationSignature(secret)
-	if err != nil {
-		t.Fatalf("Unexpected error %s", err)
-	}
-
-	tests := []struct {
-		name      string
-		shouldErr bool
-		publickey string
-	}{
-		{
-			name:      "verify using same public key",
-			shouldErr: false,
-			publickey: pub,
-		},
-		{
-			name:      "verify using another public key",
-			shouldErr: true,
-			publickey: testutil.PublicTestKey,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			verificationErr := container.VerifyPgpSignature(test.publickey, inputSig)
-			testutil.CheckError(t, test.shouldErr, verificationErr)
-		})
-	}
-}
-
-func TestGPGArmorSignVerifyIntegration(t *testing.T) {
-	container, err := NewAtomicContainerSig(goodImage, map[string]string{})
-	if err != nil {
-		t.Fatalf("Unexpected error %s", err)
-	}
-	if err := container.VerifyPgpSignature(testutil.Base64PublicTestKey(t), expectedSig); err != nil {
-		t.Fatalf("unexpected error %s", err)
 	}
 }
 


### PR DESCRIPTION
Delete unused verification operations in Kritis's `attestation` package. Kritis has migrated to `cryptolib` for this functionality.

Depends on: #525 
Diff: https://github.com/acamadeo/kritis/compare/delete-old-funcs...acamadeo:delete-old-attestation-funcs?expand=1