### PR TITLE
Add bypass-and-sign mode in signer

### DIFF
--- a/cmd/kritis/signer/main.go
+++ b/cmd/kritis/signer/main.go
@@ -119,6 +119,10 @@ func main() {
 		Project:   policy.Spec.Project,
 	})
 
+	if image == "" {
+		glog.Fatalf("Image url is empty: %s", image)
+	}
+	
 	if SignerMode(mode) == BypassAndSign {
 		r.SignImage(image)
 		return
@@ -126,10 +130,6 @@ func main() {
 
 	if SignerMode(mode) == CheckAndSign {
 		// Read the vulnz scanning events
-		if image == "" {
-			glog.Fatalf("Image url is empty: %s", image)
-		}
-
 		vulnz, err := client.Vulnerabilities(image)
 		if err != nil {
 			glog.Fatalf("Found err %s", err)

--- a/cmd/kritis/signer/main.go
+++ b/cmd/kritis/signer/main.go
@@ -32,9 +32,16 @@ import (
 	yaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 
-func main() {
-	var image, pri_key_path, passphrase, pub_key_path, policy_path string
+const (
+	SignerMode_CheckAndSign  = "check-and-sign"
+	SignerMode_CheckOnly     = "check-only"
+	SignerMode_BypassAndSign = "bypass-and-sign"
+)
 
+func main() {
+	var image, pri_key_path, passphrase, pub_key_path, policy_path, mode string
+
+	flag.StringVar(&mode, "mode", "", "mode of operation, check-and-sign|check-only|bypass-and-sign")
 	flag.StringVar(&image, "image", "", "image url, e.g., gcr.io/foo/bar@sha256:abcd")
 	flag.StringVar(&pri_key_path, "private_key", "", "signer private key path, e.g., /dev/shm/key.pgp")
 	flag.StringVar(&passphrase, "passphrase", "", "passphrase for private key, if any")
@@ -42,27 +49,26 @@ func main() {
 	flag.StringVar(&policy_path, "policy", "", "vulnerability signing policy file path, e.g., /tmp/vulnz_signing_policy.yaml")
 	flag.Parse()
 
-	glog.Infof("image: %s, s_key: %s, policy: %s", image, pri_key_path, policy_path)
+	if mode != SignerMode_CheckAndSign && mode != SignerMode_BypassAndSign {
+		if mode == SignerMode_CheckOnly {
+			glog.Fatalf("Mode %s note supported yet.", mode)
+		} else {
+			glog.Fatalf("Unrecognized mode %s.", mode)
+		}
+	}
 
 	signerKey, err := ioutil.ReadFile(pri_key_path)
 	if err != nil {
 		glog.Fatalf("Fail to read signer key: %v", err)
 	}
 
+	// Parse the vulnz signing policy
+	policy := v1beta1.VulnzSigningPolicy{}
 	policyFile, err := os.Open(policy_path)
 	if err != nil {
 		glog.Fatalf("Fail to load vulnz signing policy: %v", err)
 	}
 	defer policyFile.Close()
-
-	pubKey, err := ioutil.ReadFile(pub_key_path)
-	if err != nil {
-		glog.Fatalf("Fail to read public key: %v", err)
-	}
-
-	// Parse the vulnz signing policy
-	policy := v1beta1.VulnzSigningPolicy{}
-
 	// err = json.Unmarshal(policyFile, &policy)
 	if err := yaml.NewYAMLToJSONDecoder(policyFile).Decode(&policy); err != nil {
 		glog.Fatalf("Fail to parse policy file: %v", err)
@@ -71,21 +77,9 @@ func main() {
 		glog.Infof("Policy req: %v\n", policy.Spec.PackageVulnerabilityRequirements)
 	}
 
-	// Read the vulnz scanning events
-	if image == "" {
-		glog.Fatalf("Image url is empty: %s", image)
-	}
-
-	client, err := containeranalysis.NewCache()
+	pubKey, err := ioutil.ReadFile(pub_key_path)
 	if err != nil {
-		glog.Fatalf("Could not initialize the client %v", err)
-	}
-	vulnz, err := client.Vulnerabilities(image)
-	if err != nil {
-		glog.Fatalf("Found err %s", err)
-	}
-	if vulnz == nil {
-		glog.Fatalf("Expected some vulnerabilities. Nil found")
+		glog.Fatalf("Fail to read public key: %v", err)
 	}
 
 	// Create pgp key
@@ -110,18 +104,45 @@ func main() {
 		},
 	}
 
+	client, err := containeranalysis.NewCache()
+	if err != nil {
+		glog.Fatalf("Could not initialize the client %v", err)
+	}
+
 	r := signer.New(client, &signer.Config{
 		Validate:  vulnzsigningpolicy.ValidateVulnzSigningPolicy,
 		PgpKey:    pgpKey,
 		Authority: authority,
 		Project:   policy.Spec.Project,
 	})
-	imageVulnz := signer.ImageVulnerabilities{
-		ImageRef:        image,
-		Vulnerabilities: vulnz,
+
+	if mode == SignerMode_BypassAndSign {
+		r.SignImage(image)
+		return
 	}
 
-	if err := r.ValidateAndSign(imageVulnz, policy); err != nil {
-		glog.Fatalf("Error creating signature: %v", err)
+	if mode == SignerMode_CheckAndSign {
+		// Read the vulnz scanning events
+		if image == "" {
+			glog.Fatalf("Image url is empty: %s", image)
+		}
+
+		vulnz, err := client.Vulnerabilities(image)
+		if err != nil {
+			glog.Fatalf("Found err %s", err)
+		}
+		if vulnz == nil {
+			glog.Fatalf("Expected some vulnerabilities. Nil found")
+		}
+
+		imageVulnz := signer.ImageVulnerabilities{
+			ImageRef:        image,
+			Vulnerabilities: vulnz,
+		}
+
+		if err := r.ValidateAndSign(imageVulnz, policy); err != nil {
+			glog.Fatalf("Error creating signature: %v", err)
+		}
+		return
 	}
 }

--- a/cmd/kritis/signer/main.go
+++ b/cmd/kritis/signer/main.go
@@ -122,7 +122,7 @@ func main() {
 	if image == "" {
 		glog.Fatalf("Image url is empty: %s", image)
 	}
-	
+
 	if SignerMode(mode) == BypassAndSign {
 		r.SignImage(image)
 		return

--- a/pkg/kritis/signer/signer.go
+++ b/pkg/kritis/signer/signer.go
@@ -75,13 +75,19 @@ func (s Signer) ValidateAndSign(imageVulnz ImageVulnerabilities, vps v1beta1.Vul
 	}
 
 	glog.Infof("Image %q passes VulnzSigningPolicy %s.", imageVulnz.ImageRef, vps.Name)
-	existed, _ := s.isAttestationAlreadyExist(imageVulnz.ImageRef)
+	return s.SignImage(imageVulnz.ImageRef)
+}
+
+// ValidateAndSign signs an image without doing any policy check.
+// Returns an error if image does not pass or creating an attestation fails.
+func (s Signer) SignImage(image string) error {
+	existed, _ := s.isAttestationAlreadyExist(image)
 	if existed {
-		glog.Warningf("Attestation for image %q has already been created.", imageVulnz.ImageRef)
+		glog.Warningf("Attestation for image %q has already been created.", image)
 		return nil
 	}
-	glog.Infof("Creating attestations for image %q.", imageVulnz.ImageRef)
-	if err := s.addAttestation(imageVulnz.ImageRef); err != nil {
+	glog.Infof("Creating attestations for image %q.", image)
+	if err := s.addAttestation(image); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
`bypass-and-sign` mode will create attestation for an image without any policy check.