### PR TITLE
Update command line parameters and policy in signer demo

### DIFF
--- a/samples/signer/cloudbuild-bad.yaml
+++ b/samples/signer/cloudbuild-bad.yaml
@@ -35,10 +35,8 @@ steps:
       -v=10 \
       -alsologtostderr \
       -image=$(/bin/cat image-digest.txt) \
-      -credentials=kritis-service-account.json \
-      -private_key=gpg.priv \
-      -public_key=gpg.pub \
-      -policy=policy.yaml
+      -policy=policy.yaml \
+      -mode=check-only
     waitFor: vulnpoll
     id: vulnsign
 images: ['gcr.io/$PROJECT_ID/binauthz-test:latest']

--- a/samples/signer/cloudbuild-good.yaml
+++ b/samples/signer/cloudbuild-good.yaml
@@ -35,10 +35,8 @@ steps:
       -v=10 \
       -alsologtostderr \
       -image=$(/bin/cat image-digest.txt) \
-      -credentials=kritis-service-account.json \
-      -private_key=gpg.priv \
-      -public_key=gpg.pub \
-      -policy=policy.yaml
+      -policy=policy.yaml \
+      -mode=check-only
     waitFor: vulnpoll
     id: vulnsign
 images: ['gcr.io/$PROJECT_ID/binauthz-test:latest']

--- a/samples/signer/policy_template.yaml
+++ b/samples/signer/policy_template.yaml
@@ -3,11 +3,10 @@ kind: VulnzSigningPolicy
 metadata:
   name: my-vsp
 spec:
-  project: <ATTESTATION_PROJECT>
-  noteReference: projects/<NOTE_PROJECT>/notes/<NOTE_ID>
-  packageVulnerabilityRequirements:
-    maximumSeverity: MEDIUM
-    maximumFixNotAvailableSeverity: MEDIUM
+  imageVulnerabilityRequirements:
+    maximumFixableSeverity: MEDIUM
+    maximumUnfixableSeverity: MEDIUM
     allowlistCVEs:
-      - providers/goog-vulnz/notes/CVE-2017-1000082
-      - providers/goog-vulnz/notes/CVE-2017-1000081
+    - projects/goog-vulnz/notes/CVE-2020-10543
+    - projects/goog-vulnz/notes/CVE-2020-10878
+    - projects/goog-vulnz/notes/CVE-2020-14155


### PR DESCRIPTION
In conjunction with #545, this PR should reduce the signer demo's scope to policy check.
It also updates the policy template so that it conforms to new policy spec.
It then adds a new allowlisted CVE. (The Debian10 image was discovered a new vulnz that broke the "good" case. The added allowlisted CVE will fix that.)