### PR TITLE
Pinpoint debian versions in Dockerfile

### DIFF
--- a/integration/signer/Dockerfile.bad
+++ b/integration/signer/Dockerfile.bad
@@ -1,3 +1,5 @@
-FROM gcr.io/google-appengine/debian9:latest
+# Debian9 image from Jun 8th, 2020
+FROM gcr.io/google-appengine/debian9@sha256:023748401f33e710de6297c7e7dd1617f3c3654819885c5208e9df4d0697848e
 
+# Just so the built image is always unique
 RUN apt-get update && apt-get -y install uuid-runtime && uuidgen > /IAMUNIQUE

--- a/integration/signer/Dockerfile.good
+++ b/integration/signer/Dockerfile.good
@@ -1,3 +1,5 @@
-FROM gcr.io/google-appengine/debian10:latest
+# Debian9 image from Jun 8th, 2020
+FROM gcr.io/google-appengine/debian10@sha256:d2e40ef81a0f353f1b9c3cf07e384a1f23db3acdaa0eae4c269b653ab45ffadf
 
+# Just so the built image is always unique
 RUN apt-get update && apt-get -y install uuid-runtime && uuidgen > /IAMUNIQUE

--- a/samples/signer/Dockerfile.bad
+++ b/samples/signer/Dockerfile.bad
@@ -1,3 +1,5 @@
-FROM gcr.io/google-appengine/debian9:latest
+# Debian9 image from Jun 8th, 2020
+FROM gcr.io/google-appengine/debian9@sha256:023748401f33e710de6297c7e7dd1617f3c3654819885c5208e9df4d0697848e
 
+# Just so the built image is always unique
 RUN apt-get update && apt-get -y install uuid-runtime && uuidgen > /IAMUNIQUE

--- a/samples/signer/Dockerfile.good
+++ b/samples/signer/Dockerfile.good
@@ -1,3 +1,5 @@
-FROM gcr.io/google-appengine/debian10:latest
+# Debian10 image from Jun 8th, 2020
+FROM gcr.io/google-appengine/debian10@sha256:d2e40ef81a0f353f1b9c3cf07e384a1f23db3acdaa0eae4c269b653ab45ffadf
 
+# Just so the built image is always unique
 RUN apt-get update && apt-get -y install uuid-runtime && uuidgen > /IAMUNIQUE


### PR DESCRIPTION
Use digest instead of `latest` tag in those Dockerfile, so new Debian releases would not change vulnerability results completely.

However, vulnerability results could still change for the images, as new vulnerabilities are being discovered.

This should make signer integration testing and samples more stable.