### PR TITLE
Use cryptolib signer in kritis signer

### DIFF
--- a/cmd/kritis/signer/main.go
+++ b/cmd/kritis/signer/main.go
@@ -29,7 +29,6 @@ import (
 	"github.com/grafeas/kritis/pkg/kritis/metadata/containeranalysis"
 	"github.com/grafeas/kritis/pkg/kritis/signer"
 	"github.com/grafeas/kritis/pkg/kritis/util"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
@@ -42,16 +41,16 @@ const (
 )
 
 func main() {
-	var image, vulnz_timeout, pri_key_path, passphrase, policy_path, mode, attestation_project, note_name string
-
-	flag.StringVar(&mode, "mode", "check-and-sign", "mode of operation, check-and-sign|check-only|bypass-and-sign")
+	var (
+		mode, image, vulnzTimeout, priKeyPath, passphrase, policyPath, attestationProject, noteName string
+	)
 	flag.StringVar(&image, "image", "", "image url, e.g., gcr.io/foo/bar@sha256:abcd")
-	flag.StringVar(&vulnz_timeout, "vulnz_timeout", "5m", "timeout for polling image vulnerability , e.g., 600s, 5m")
-	flag.StringVar(&pri_key_path, "private_key", "", "signer private key path, e.g., /dev/shm/key.pgp")
+	flag.StringVar(&vulnzTimeout, "vulnzTimeout", "5m", "timeout for polling image vulnerability , e.g., 600s, 5m")
+	flag.StringVar(&priKeyPath, "private_key", "", "signer private key path, e.g., /dev/shm/key.pgp")
 	flag.StringVar(&passphrase, "passphrase", "", "passphrase for private key, if any")
-	flag.StringVar(&policy_path, "policy", "", "vulnerability signing policy file path, e.g., /tmp/vulnz_signing_policy.yaml")
-	flag.StringVar(&note_name, "note_name", "", "note name that created attestations are attached to, in the form of projects/[PROVIDER_ID]/notes/[NOTE_ID]")
-	flag.StringVar(&attestation_project, "attestation_project", "", "project id for GCP project that stores attestation, default to image project if unspecified")
+	flag.StringVar(&policyPath, "policy", "", "vulnerability signing policy file path, e.g., /tmp/vulnz_signing_policy.yaml")
+	flag.StringVar(&noteName, "noteName", "", "note name that created attestations are attached to, in the form of projects/[PROVIDER_ID]/notes/[NOTE_ID]")
+	flag.StringVar(&attestationProject, "attestationProject", "", "project id for GCP project that stores attestation, default to image project if unspecified")
 	flag.Parse()
 
 	doCheck, doSign := false, false
@@ -83,7 +82,7 @@ func main() {
 	if doCheck {
 		// Read the vulnz signing policy
 		policy := v1beta1.VulnzSigningPolicy{}
-		policyFile, err := os.Open(policy_path)
+		policyFile, err := os.Open(policyPath)
 		if err != nil {
 			glog.Fatalf("Fail to load vulnz signing policy: %v", err)
 		}
@@ -95,7 +94,7 @@ func main() {
 			glog.Infof("Policy req: %v\n", policy.Spec.ImageVulnerabilityRequirements)
 		}
 
-		timeout, err := time.ParseDuration(vulnz_timeout)
+		timeout, err := time.ParseDuration(vulnzTimeout)
 		if err != nil {
 			glog.Fatalf("Fail to parse timeout %v", err)
 		}
@@ -134,7 +133,7 @@ func main() {
 			glog.Fatalf("Passphrase is not yet supported.\n")
 		}
 		// Read the signing credentials
-		signerKey, err := ioutil.ReadFile(pri_key_path)
+		signerKey, err := ioutil.ReadFile(priKeyPath)
 		if err != nil {
 			glog.Fatalf("Fail to read signer key: %v", err)
 		}
@@ -145,38 +144,21 @@ func main() {
 		}
 
 		// Check note name
-		err = util.CheckNoteName(note_name)
+		err = util.CheckNoteName(noteName)
 		if err != nil {
 			glog.Fatalf("Note name is invalid %v", err)
 		}
 
 		// Parse attestation project
-		if attestation_project == "" {
-			attestation_project = util.GetProjectFromContainerImage(image)
-			glog.Infof("Using image project as attestation project: %s\n", attestation_project)
+		if attestationProject == "" {
+			attestationProject = util.GetProjectFromContainerImage(image)
+			glog.Infof("Using image project as attestation project: %s\n", attestationProject)
 		} else {
-			glog.Infof("Using specified attestation project: %s\n", attestation_project)
-		}
-
-		// Create AA
-		// Create an AttestaionAuthority to help create noteOcurrences.
-		// This is quite hacky.
-		// TODO: refactor out the authority code
-		authority := v1beta1.AttestationAuthority{
-			ObjectMeta: metav1.ObjectMeta{Name: "signing-aa"},
-			Spec: v1beta1.AttestationAuthoritySpec{
-				NoteReference: note_name,
-				PublicKeys: []v1beta1.PublicKey{
-					{
-						KeyType:                  "PGP",
-						AsciiArmoredPgpPublicKey: "",
-					},
-				},
-			},
+			glog.Infof("Using specified attestation project: %s\n", attestationProject)
 		}
 
 		// Create signer
-		r := signer.New(client, cSigner, authority, attestation_project)
+		r := signer.New(client, cSigner, noteName, attestationProject)
 		// Sign image
 		r.SignImage(image)
 	}

--- a/cmd/kritis/signer/main.go
+++ b/cmd/kritis/signer/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"encoding/base64"
 	"flag"
 	"io/ioutil"
 	"os"
@@ -28,7 +27,6 @@ import (
 	"github.com/grafeas/kritis/pkg/kritis/crd/vulnzsigningpolicy"
 	"github.com/grafeas/kritis/pkg/kritis/cryptolib"
 	"github.com/grafeas/kritis/pkg/kritis/metadata/containeranalysis"
-	"github.com/grafeas/kritis/pkg/kritis/secrets"
 	"github.com/grafeas/kritis/pkg/kritis/signer"
 	"github.com/grafeas/kritis/pkg/kritis/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/cmd/kritis/signer/main.go
+++ b/cmd/kritis/signer/main.go
@@ -40,10 +40,18 @@ const (
 	BypassAndSign SignerMode = "bypass-and-sign"
 )
 
-func main() {
-	var (
-		mode, image, vulnzTimeout, priKeyPath, passphrase, policyPath, attestationProject, noteName string
-	)
+var (
+	mode               string
+	image              string
+	vulnzTimeout       string
+	priKeyPath         string
+	passphrase         string
+	policyPath         string
+	attestationProject string
+	noteName           string
+)
+
+func init() {
 	flag.StringVar(&image, "image", "", "image url, e.g., gcr.io/foo/bar@sha256:abcd")
 	flag.StringVar(&vulnzTimeout, "vulnzTimeout", "5m", "timeout for polling image vulnerability , e.g., 600s, 5m")
 	flag.StringVar(&priKeyPath, "private_key", "", "signer private key path, e.g., /dev/shm/key.pgp")
@@ -51,6 +59,9 @@ func main() {
 	flag.StringVar(&policyPath, "policy", "", "vulnerability signing policy file path, e.g., /tmp/vulnz_signing_policy.yaml")
 	flag.StringVar(&noteName, "noteName", "", "note name that created attestations are attached to, in the form of projects/[PROVIDER_ID]/notes/[NOTE_ID]")
 	flag.StringVar(&attestationProject, "attestationProject", "", "project id for GCP project that stores attestation, default to image project if unspecified")
+}
+
+func main() {
 	flag.Parse()
 
 	doCheck, doSign := false, false

--- a/integration/signer/tests/test-bypass-and-sign.sh
+++ b/integration/signer/tests/test-bypass-and-sign.sh
@@ -36,7 +36,6 @@ trap 'delete_occ $GOOD_IMG_DIGEST_URL'  EXIT
 -alsologtostderr \
 -mode=bypass-and-sign \
 -image=${GOOD_IMG_DIGEST_URL} \
--public_key=public.key \
 -private_key=private.key \
 -policy=policy.yaml \
 -note_name=${NOTE_NAME}

--- a/integration/signer/tests/test-check-and-sign-bad.sh
+++ b/integration/signer/tests/test-check-and-sign-bad.sh
@@ -36,7 +36,6 @@ signing_bad_image_failed=false
 ./signer -v 10 \
 -alsologtostderr \
 -image=${BAD_IMG_DIGEST_URL} \
--public_key=public.key \
 -private_key=private.key \
 -policy=policy.yaml \
 -note_name=${NOTE_NAME} || signing_bad_image_failed=true

--- a/integration/signer/tests/test-check-and-sign-good.sh
+++ b/integration/signer/tests/test-check-and-sign-good.sh
@@ -36,7 +36,6 @@ trap 'delete_occ $GOOD_IMG_DIGEST_URL'  EXIT
 ./signer -v 10 \
 -alsologtostderr \
 -image=${GOOD_IMG_DIGEST_URL} \
--public_key=public.key \
 -private_key=private.key \
 -policy=policy.yaml \
 -note_name=${NOTE_NAME}

--- a/pkg/kritis/signer/signer.go
+++ b/pkg/kritis/signer/signer.go
@@ -19,9 +19,10 @@ package signer
 import (
 	"github.com/golang/glog"
 	"github.com/grafeas/kritis/pkg/kritis/apis/kritis/v1beta1"
+	"github.com/grafeas/kritis/pkg/kritis/attestation"
 	"github.com/grafeas/kritis/pkg/kritis/crd/authority"
+	"github.com/grafeas/kritis/pkg/kritis/cryptolib"
 	"github.com/grafeas/kritis/pkg/kritis/metadata"
-	"github.com/grafeas/kritis/pkg/kritis/secrets"
 	"github.com/grafeas/kritis/pkg/kritis/util"
 )
 
@@ -33,16 +34,20 @@ type Signer struct {
 
 // A signer config that includes necessary data and handler for signing.
 type Config struct {
-	PgpKey    *secrets.PgpKey
-	Authority v1beta1.AttestationAuthority
-	Project   string
+	cSigner    cryptolib.Signer
+	authority v1beta1.AttestationAuthority
+	project   string
 }
 
 // Creating a new signer object.
-func New(client metadata.ReadWriteClient, c *Config) Signer {
+func New(client metadata.ReadWriteClient, cSigner cryptolib.Signer, authority v1beta1.AttestationAuthority,  project string) Signer {
 	return Signer{
 		client: client,
-		config: c,
+		config: &Config{
+			cSigner,
+			authority,
+			project,
+		},
 	}
 }
 
@@ -65,34 +70,51 @@ func (s Signer) SignImage(image string) error {
 		glog.Warningf("Attestation for image %q has already been created.", image)
 		return nil
 	}
+
 	glog.Infof("Creating attestations for image %q.", image)
-	if err := s.addAttestation(image); err != nil {
+	// Create attestation
+	att, err := s.createAttestation(image)
+	if err != nil {
+		return err
+	}
+
+	glog.Infof("Uploading attestations for image %q.", image)
+	if err := s.uploadAttestation(image, att); err != nil {
 		return err
 	}
 	return nil
 }
 
-// Creating an attestation if not already exist under the same note.
+// Creating an atestation.
+func (s Signer) createAttestation(image string) (*cryptolib.Attestation, error) {
+	payload, err := attestation.AtomicContainerPayload(image)
+	if err != nil {
+		return nil, err
+	}
+
+	att, err := s.config.cSigner.CreateAttestation(payload)
+	if err != nil {
+		return nil, err
+	}
+	return att, nil
+}
+
+// Uploading an attestation if not already exist under the same note.
 // The method will create a note if it does not already exist.
-// Returns error if creation failed, e.g., if an attestation already exists.
-func (s Signer) addAttestation(image string) error {
-	n, err := util.GetOrCreateAttestationNote(s.client, &s.config.Authority)
+// Returns error if upload failed, e.g., if an attestation already exists.
+func (s Signer) uploadAttestation(image string, att *cryptolib.Attestation) error {
+	n, err := util.GetOrCreateAttestationNote(s.client, &s.config.authority)
 	if err != nil {
 		return err
 	}
-	// Create secret for this authority
-	sec := &secrets.PGPSigningSecret{
-		PgpKey:     s.config.PgpKey,
-		SecretName: "signing-secret",
-	}
 
-	// Create Attestation Signature
-	_, err = s.client.CreateAttestationOccurrence(n.GetName(), image, sec, s.config.Project)
+	// Upload attestation
+	_, err = s.client.UploadAttestationOccurrence(n.GetName(), image, att, s.config.project, metadata.PgpSignatureType)
 	return err
 }
 
 func (s Signer) isAttestationAlreadyExist(image string) (bool, error) {
-	atts, err := s.client.Attestations(image, &s.config.Authority)
+	atts, err := s.client.Attestations(image, &s.config.authority)
 	if err == nil && len(atts) > 0 {
 		return true, nil
 	}

--- a/pkg/kritis/signer/signer.go
+++ b/pkg/kritis/signer/signer.go
@@ -34,13 +34,13 @@ type Signer struct {
 
 // A signer config that includes necessary data and handler for signing.
 type Config struct {
-	cSigner    cryptolib.Signer
+	cSigner   cryptolib.Signer
 	authority v1beta1.AttestationAuthority
 	project   string
 }
 
 // Creating a new signer object.
-func New(client metadata.ReadWriteClient, cSigner cryptolib.Signer, authority v1beta1.AttestationAuthority,  project string) Signer {
+func New(client metadata.ReadWriteClient, cSigner cryptolib.Signer, authority v1beta1.AttestationAuthority, project string) Signer {
 	return Signer{
 		client: client,
 		config: &Config{

--- a/pkg/kritis/signer/signer.go
+++ b/pkg/kritis/signer/signer.go
@@ -30,12 +30,12 @@ import (
 
 // A signer is used for creating attestations for an image.
 type Signer struct {
-	config *Config
+	config *config
 	client metadata.ReadWriteClient
 }
 
 // A signer config that includes necessary data and handler for signing.
-type Config struct {
+type config struct {
 	cSigner cryptolib.Signer
 	// an AttestaionAuthority that is used in metadata client APIs.
 	// We should consider refactor it out because:
@@ -50,7 +50,7 @@ type Config struct {
 func New(client metadata.ReadWriteClient, cSigner cryptolib.Signer, noteName string, project string) Signer {
 	return Signer{
 		client: client,
-		config: &Config{
+		config: &config{
 			cSigner,
 			v1beta1.AttestationAuthority{
 				ObjectMeta: metav1.ObjectMeta{Name: "signing-aa"},


### PR DESCRIPTION
This makes the signing module in Kritis signer to be pluggable. 
As a byproduct, it removes need for public key.

Regression: it no longer supports passphrase protected private key. We should support is back soon. I think the best place to add the support is in the crypto library, e.g., refactoring `NewPgpSigner` to take in an additional `passphrase` parameter.