### PR TITLE
Rename KeyType to AuthenticatorType

### DIFF
--- a/pkg/kritis/cryptolib/jwt_test.go
+++ b/pkg/kritis/cryptolib/jwt_test.go
@@ -25,7 +25,7 @@ const jwtWithInvalidHeaderTYP = "eyAgImFsZyI6ICJFUzI1NiIsICJ0eXAiOiAiQkFEVFlQRSI
 const jwtWithCrit = "eyJhbGciOiJFUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoibXktc2lnbmluZy1rZXkiLCAiY3JpdCI6ICJsaXN0LW9mLWZpZWxkcyJ9Cg.eyAic3ViIjogImNvbnRhaW5lcjpkaWdlc3Q6c2hhMjU2OmZha2UtZGlnZXN0IiwgImF1ZCI6ICIvL2JpbmFyeWF1dGhvcml6YXRpb24uZ29vZ2xlYXBpcy5jb20iLCAiYXR0ZXN0YXRpb25UeXBlIjogIlRCRCIsICJhdHRlc3RhdGlvbiI6ICIiIH0K.someisgnature"
 
 var goodPubKey = PublicKey{
-	KeyType:            Jwt,
+	AuthenticatorType:  Jwt,
 	SignatureAlgorithm: EcdsaP256Sha256,
 	ID:                 "my-signing-key",
 	KeyData:            []byte("some-key"),
@@ -49,10 +49,10 @@ func TestVerifyJWT(t *testing.T) {
 			pubkey:        goodPubKey,
 			expectedError: true,
 		}, {
-			name: "PublicKey KeyType does not match ALG in JWT header",
+			name: "PublicKey AuthenticatorType does not match ALG in JWT header",
 			jwt:  []byte(goodJwt),
 			pubkey: PublicKey{
-				KeyType:            Jwt,
+				AuthenticatorType:  Jwt,
 				SignatureAlgorithm: RsaSignPkcs14096Sha256,
 				ID:                 "my-signing-key",
 				KeyData:            []byte("some-key"),
@@ -62,7 +62,7 @@ func TestVerifyJWT(t *testing.T) {
 			name: "PublicKey ID does not match KID in JWT header",
 			jwt:  []byte(goodJwt),
 			pubkey: PublicKey{
-				KeyType:            Jwt,
+				AuthenticatorType:  Jwt,
 				SignatureAlgorithm: EcdsaP256Sha256,
 				ID:                 "some-key-id",
 				KeyData:            []byte("some-key"),

--- a/pkg/kritis/cryptolib/public_key.go
+++ b/pkg/kritis/cryptolib/public_key.go
@@ -41,17 +41,17 @@ type PublicKey struct {
 }
 
 // NewPublicKey creates a new PublicKey.
-// `authType` indicates the transport format of the Attestation this PublicKey
-// verifies, one of Pgp, Pkix or Jwt.
+// `authenticatorType` indicates the transport format of the Attestation this
+// PublicKey verifies, one of Pgp, Pkix or Jwt.
 // `keyData` contains the raw key material.
 // `keyID` contains a unique identifier for the public key. For PGP, this field
 // should be left blank. The ID will be the OpenPGP RFC4880 V4 fingerprint of
 // the key. For PKIX and JWT, this may be left blank, and the ID  will be
 // generated based on the DER encoding of the key. If not blank, the ID should
 // be a StringOrURI: it must either not contain ":" or be a valid URI.
-func NewPublicKey(authType AuthenticatorType, keyData []byte, keyID string) (*PublicKey, error) {
+func NewPublicKey(authenticatorType AuthenticatorType, keyData []byte, keyID string) (*PublicKey, error) {
 	newKeyID := ""
-	switch authType {
+	switch authenticatorType {
 	case Pgp:
 		id, err := extractPgpKeyID(keyData)
 		if err != nil {
@@ -69,7 +69,7 @@ func NewPublicKey(authType AuthenticatorType, keyData []byte, keyID string) (*Pu
 	}
 
 	return &PublicKey{
-		AuthenticatorType: authType,
+		AuthenticatorType: authenticatorType,
 		KeyData:           keyData,
 		ID:                newKeyID,
 	}, nil

--- a/pkg/kritis/cryptolib/public_key.go
+++ b/pkg/kritis/cryptolib/public_key.go
@@ -27,8 +27,9 @@ import (
 
 // PublicKey stores public key material for all key types.
 type PublicKey struct {
-	// KeyType stores the type of the public key, one of Pgp, Pkix, or Jwt.
-	KeyType KeyType
+	// AuthenticatorType indicates the transport format of the Attestation this
+	// key verifies, one of Pgp, Pkix, or Jwt.
+	AuthenticatorType AuthenticatorType
 	// Signature Algorithm holds the signing and padding algorithm for the signature.
 	SignatureAlgorithm SignatureAlgorithm
 	// KeyData holds the raw key material which can verify a signature.
@@ -39,16 +40,18 @@ type PublicKey struct {
 	ID string
 }
 
-// NewPublicKey creates a new PublicKey. `keyType` contains the type of the
-// public key, one of Pgp, Pkix or Jwt. `keyData` contains the raw key
-// material. `keyID` contains a unique identifier for the public key. For PGP,
-// this field should be left blank. The ID will be the OpenPGP RFC4880 V4
-// fingerprint of the key. For PKIX and JWT, this may be left blank, and the ID
-// will be generated based on the DER encoding of the key. If not blank, the ID
-// should be a StringOrURI: it must either not contain ":" or be a valid URI.
-func NewPublicKey(keyType KeyType, keyData []byte, keyID string) (*PublicKey, error) {
+// NewPublicKey creates a new PublicKey.
+// `authType` indicates the transport format of the Attestation this PublicKey
+// verifies, one of Pgp, Pkix or Jwt.
+// `keyData` contains the raw key material.
+// `keyID` contains a unique identifier for the public key. For PGP, this field
+// should be left blank. The ID will be the OpenPGP RFC4880 V4 fingerprint of
+// the key. For PKIX and JWT, this may be left blank, and the ID  will be
+// generated based on the DER encoding of the key. If not blank, the ID should
+// be a StringOrURI: it must either not contain ":" or be a valid URI.
+func NewPublicKey(authType AuthenticatorType, keyData []byte, keyID string) (*PublicKey, error) {
 	newKeyID := ""
-	switch keyType {
+	switch authType {
 	case Pgp:
 		id, err := extractPgpKeyID(keyData)
 		if err != nil {
@@ -62,13 +65,13 @@ func NewPublicKey(keyType KeyType, keyData []byte, keyID string) (*PublicKey, er
 		}
 		newKeyID = id
 	default:
-		return nil, fmt.Errorf("invalid key type")
+		return nil, fmt.Errorf("invalid AuthenticatorType")
 	}
 
 	return &PublicKey{
-		KeyType: keyType,
-		KeyData: keyData,
-		ID:      newKeyID,
+		AuthenticatorType: authType,
+		KeyData:           keyData,
+		ID:                newKeyID,
 	}, nil
 }
 

--- a/pkg/kritis/cryptolib/signature_algorithm.go
+++ b/pkg/kritis/cryptolib/signature_algorithm.go
@@ -49,12 +49,14 @@ const (
 	EcdsaP521Sha512
 )
 
-// KeyType is the type of a public key
-type KeyType int
+// AuthenticatorType specifies the transport format of the Attestation. It
+// indicates to the Verifier how to extract the appropriate information out of
+// an Attestation.
+type AuthenticatorType int
 
-// Enumeration of KeyType
+// Enumeration of AuthenticatorType
 const (
-	UnknownKeyType KeyType = iota
+	UnknownAuthenticatorType AuthenticatorType = iota
 	Pgp
 	Pkix
 	Jwt

--- a/pkg/kritis/cryptolib/verifier.go
+++ b/pkg/kritis/cryptolib/verifier.go
@@ -112,7 +112,7 @@ func (v *verifier) VerifyAttestation(att *Attestation) error {
 
 	var err error
 	payload := []byte{}
-	switch publicKey.KeyType {
+	switch publicKey.AuthenticatorType {
 	case Pkix:
 		err = v.verifyPkix(att.Signature, att.SerializedPayload, publicKey.KeyData)
 		payload = att.SerializedPayload

--- a/pkg/kritis/cryptolib/verifier_test.go
+++ b/pkg/kritis/cryptolib/verifier_test.go
@@ -74,7 +74,7 @@ const verifierPublicKeyID = "446625EB36036D7546B2D63B77B4BE6989834233"
 func TestNewPublicKey(t *testing.T) {
 	tcs := []struct {
 		name        string
-		keyType     KeyType
+		authType    AuthenticatorType
 		keyData     []byte
 		keyID       string
 		expectedErr bool
@@ -82,7 +82,7 @@ func TestNewPublicKey(t *testing.T) {
 	}{
 		{
 			name:        "valid PGP key ID",
-			keyType:     Pgp,
+			authType:    Pgp,
 			keyData:     []byte(verifierPublicKey),
 			keyID:       verifierPublicKeyID,
 			expectedErr: false,
@@ -90,7 +90,7 @@ func TestNewPublicKey(t *testing.T) {
 		},
 		{
 			name:        "incorrect PGP key ID",
-			keyType:     Pgp,
+			authType:    Pgp,
 			keyData:     []byte(verifierPublicKey),
 			keyID:       "incorrect-id",
 			expectedErr: false,
@@ -98,26 +98,26 @@ func TestNewPublicKey(t *testing.T) {
 		},
 		{
 			name:        "valid PKIX key ID",
-			keyType:     Pkix,
+			authType:    Pkix,
 			keyID:       "valid-key-id",
 			expectedErr: false,
 			expectedID:  "valid-key-id",
 		},
 		{
 			name:        "invalid PKIX key ID",
-			keyType:     Pkix,
+			authType:    Pkix,
 			keyID:       ":{invalid-key-id}",
 			expectedErr: true,
 		},
 		{
-			name:        "unknown key type",
-			keyType:     UnknownKeyType,
+			name:        "unknown authenticator type",
+			authType:    UnknownAuthenticatorType,
 			expectedErr: true,
 		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			publicKey, err := NewPublicKey(tc.keyType, tc.keyData, tc.keyID)
+			publicKey, err := NewPublicKey(tc.authType, tc.keyData, tc.keyID)
 			if tc.expectedErr {
 				if err == nil {
 					t.Errorf("Got nil err, expected not-nil")

--- a/pkg/kritis/cryptolib/verifier_test.go
+++ b/pkg/kritis/cryptolib/verifier_test.go
@@ -73,51 +73,51 @@ const verifierPublicKeyID = "446625EB36036D7546B2D63B77B4BE6989834233"
 
 func TestNewPublicKey(t *testing.T) {
 	tcs := []struct {
-		name        string
-		authType    AuthenticatorType
-		keyData     []byte
-		keyID       string
-		expectedErr bool
-		expectedID  string
+		name              string
+		authenticatorType AuthenticatorType
+		keyData           []byte
+		keyID             string
+		expectedErr       bool
+		expectedID        string
 	}{
 		{
-			name:        "valid PGP key ID",
-			authType:    Pgp,
-			keyData:     []byte(verifierPublicKey),
-			keyID:       verifierPublicKeyID,
-			expectedErr: false,
-			expectedID:  verifierPublicKeyID,
+			name:              "valid PGP key ID",
+			authenticatorType: Pgp,
+			keyData:           []byte(verifierPublicKey),
+			keyID:             verifierPublicKeyID,
+			expectedErr:       false,
+			expectedID:        verifierPublicKeyID,
 		},
 		{
-			name:        "incorrect PGP key ID",
-			authType:    Pgp,
-			keyData:     []byte(verifierPublicKey),
-			keyID:       "incorrect-id",
-			expectedErr: false,
-			expectedID:  verifierPublicKeyID,
+			name:              "incorrect PGP key ID",
+			authenticatorType: Pgp,
+			keyData:           []byte(verifierPublicKey),
+			keyID:             "incorrect-id",
+			expectedErr:       false,
+			expectedID:        verifierPublicKeyID,
 		},
 		{
-			name:        "valid PKIX key ID",
-			authType:    Pkix,
-			keyID:       "valid-key-id",
-			expectedErr: false,
-			expectedID:  "valid-key-id",
+			name:              "valid PKIX key ID",
+			authenticatorType: Pkix,
+			keyID:             "valid-key-id",
+			expectedErr:       false,
+			expectedID:        "valid-key-id",
 		},
 		{
-			name:        "invalid PKIX key ID",
-			authType:    Pkix,
-			keyID:       ":{invalid-key-id}",
-			expectedErr: true,
+			name:              "invalid PKIX key ID",
+			authenticatorType: Pkix,
+			keyID:             ":{invalid-key-id}",
+			expectedErr:       true,
 		},
 		{
-			name:        "unknown authenticator type",
-			authType:    UnknownAuthenticatorType,
-			expectedErr: true,
+			name:              "unknown authenticator type",
+			authenticatorType: UnknownAuthenticatorType,
+			expectedErr:       true,
 		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			publicKey, err := NewPublicKey(tc.authType, tc.keyData, tc.keyID)
+			publicKey, err := NewPublicKey(tc.authenticatorType, tc.keyData, tc.keyID)
 			if tc.expectedErr {
 				if err == nil {
 					t.Errorf("Got nil err, expected not-nil")


### PR DESCRIPTION
`KeyType` is an enum with values {Pgp, Jwt, Pkix}. This can be confusing, since "Jwt" is not a type of cryptographic key, but rather a signature transport format. `KeyType` is used in cryptolib to indicate the transport format of the Attestation and how to extract meaningful information from it during verification.