### PR TITLE
Fix cloud build signer integration test

### DIFF
--- a/integration/signer/signer_int.sh
+++ b/integration/signer/signer_int.sh
@@ -92,6 +92,24 @@ delete_occ() {
     fi
 }
 
+read_occ() {
+    set +ex
+    IMG_DIGEST_URL_TO_READ=$1
+    if [ -n "$IMG_DIGEST_URL_TO_READ" ]; then
+      OCC_NAME=$(get_occ $IMG_DIGEST_URL_TO_READ)
+      echo "Delete occurrence if created."
+      if [ -n "$OCC_NAME" ]; then
+          ACCESS_TOKEN=$(gcloud --project ${PROJECT_ID} auth print-access-token)
+          echo "Delete occurrence ${OCC_NAME}."
+          curl -X GET \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${ACCESS_TOKEN}"  \
+              -H "x-goog-user-project: ${PROJECT_ID}" \
+              "https://containeranalysis.googleapis.com/v1/${OCC_NAME}"
+      fi
+    fi
+}
+
 deploy_image() {
   IMAGE_URL=$1
   POD_NAME=$2
@@ -108,6 +126,7 @@ delete_pod() {
 
 # exporting helper functions
 export -f get_occ
+export -f read_occ
 export -f urlencode
 
 # exporting clean-up task functions.

--- a/integration/signer/tests/test-bypass-and-sign-with-kms.sh
+++ b/integration/signer/tests/test-bypass-and-sign-with-kms.sh
@@ -47,6 +47,8 @@ trap 'clean_up'  EXIT
 clean_up() { ARG=$?; delete_image $GOOD_IMAGE_URL; delete_occ $GOOD_IMG_DIGEST_URL; delete_pod signer-int-test-pod; exit $ARG;}
 trap 'clean_up'  EXIT
 
+sleep 5
+
 deploy_image ${GOOD_IMG_DIGEST_URL} signer-int-test-pod
 
 echo ""

--- a/integration/signer/tests/test-bypass-and-sign-with-kms.sh
+++ b/integration/signer/tests/test-bypass-and-sign-with-kms.sh
@@ -47,7 +47,7 @@ trap 'clean_up'  EXIT
 clean_up() { ARG=$?; delete_image $GOOD_IMAGE_URL; delete_occ $GOOD_IMG_DIGEST_URL; delete_pod signer-int-test-pod; exit $ARG;}
 trap 'clean_up'  EXIT
 
-sleep 5
+read_occ $GOOD_IMAGE_URL
 
 deploy_image ${GOOD_IMG_DIGEST_URL} signer-int-test-pod
 

--- a/integration/signer/tests/test-bypass-and-sign.sh
+++ b/integration/signer/tests/test-bypass-and-sign.sh
@@ -46,7 +46,7 @@ trap 'clean_up'  EXIT
 clean_up() { ARG=$?; delete_image $GOOD_IMAGE_URL; delete_occ $GOOD_IMG_DIGEST_URL; delete_pod signer-int-test-pod; exit $ARG;}
 trap 'clean_up'  EXIT
 
-sleep 5
+read_occ $GOOD_IMAGE_URL
 
 deploy_image ${GOOD_IMG_DIGEST_URL} signer-int-test-pod
 

--- a/integration/signer/tests/test-bypass-and-sign.sh
+++ b/integration/signer/tests/test-bypass-and-sign.sh
@@ -46,6 +46,8 @@ trap 'clean_up'  EXIT
 clean_up() { ARG=$?; delete_image $GOOD_IMAGE_URL; delete_occ $GOOD_IMG_DIGEST_URL; delete_pod signer-int-test-pod; exit $ARG;}
 trap 'clean_up'  EXIT
 
+sleep 5
+
 deploy_image ${GOOD_IMG_DIGEST_URL} signer-int-test-pod
 
 

--- a/integration/signer/tests/test-check-and-sign-good.sh
+++ b/integration/signer/tests/test-check-and-sign-good.sh
@@ -46,7 +46,7 @@ trap 'clean_up'  EXIT
 clean_up() { ARG=$?; delete_image $GOOD_IMAGE_URL; delete_occ $GOOD_IMG_DIGEST_URL; delete_pod signer-int-test-pod; exit $ARG;}
 trap 'clean_up'  EXIT
 
-sleep 5
+read_occ $GOOD_IMAGE_URL
 
 deploy_image ${GOOD_IMG_DIGEST_URL} signer-int-test-pod
 

--- a/integration/signer/tests/test-check-and-sign-good.sh
+++ b/integration/signer/tests/test-check-and-sign-good.sh
@@ -46,6 +46,8 @@ trap 'clean_up'  EXIT
 clean_up() { ARG=$?; delete_image $GOOD_IMAGE_URL; delete_occ $GOOD_IMG_DIGEST_URL; delete_pod signer-int-test-pod; exit $ARG;}
 trap 'clean_up'  EXIT
 
+sleep 5
+
 deploy_image ${GOOD_IMG_DIGEST_URL} signer-int-test-pod
 
 echo ""


### PR DESCRIPTION
Explicitly read created attestation before deployment.

I believe the test error is caused by read-after-write consistency in occurrence storage. Sometimes an explicit read could trigger consistency...we never know, but at least the tests pass in this PR.
