### PR TITLE
Increase time limit on cloud build integration

### DIFF
--- a/integration/signer/cloudbuild.yaml
+++ b/integration/signer/cloudbuild.yaml
@@ -11,3 +11,5 @@ steps:
       cd integration/signer &&
       ./signer_int.sh
   env: ['PROJECT_ID=$PROJECT_ID', 'BUILD_ID=$BUILD_ID']
+  timeout: 900s
+timeout: 1200s


### PR DESCRIPTION
This mitigates timeout issue for GCB-based signer integration testing (variation 5min~9min, and recently over 10min limit in #593).