### PR TITLE
Add go mod vendor in test.sh to fix module version mismatch

### DIFF
--- a/hack/test.sh
+++ b/hack/test.sh
@@ -17,6 +17,7 @@
 if [ ! -x "$(command -v gotestsum)" ] && [ ! -x $GOPATH/bin/gotestsum ]; then
     echo "gotestsum not found, try installing it..."
     go get -u gotest.tools/gotestsum
+    go mod vendor
 fi
 
 set -e


### PR DESCRIPTION
Our travis test fails because of `go.mod` and `vendor/modules.txt` mismatch.
The mismatch is introduced by `go get -u gotest.tools/gotestsum` during the testing setup. This command updates `go.mod` but not `vendor/modules.txt`.

Fix is to add `go mod vendor` after downloading `gotestsum`.