### PR TITLE
Install gotestsum outside of kritis folder

### DIFF
--- a/hack/test.sh
+++ b/hack/test.sh
@@ -16,8 +16,9 @@
 
 if [ ! -x "$(command -v gotestsum)" ] && [ ! -x $GOPATH/bin/gotestsum ]; then
     echo "gotestsum not found, try installing it..."
+    cd ..
     go get -u gotest.tools/gotestsum
-    go mod vendor
+    cd kritis
 fi
 
 set -e

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -16,6 +16,8 @@
 
 if [ ! -x "$(command -v gotestsum)" ] && [ ! -x $GOPATH/bin/gotestsum ]; then
     echo "gotestsum not found, try installing it..."
+    # go get needs to run outside of kritis folder to avoid
+    # changes to go.mod
     cd ..
     go get -u gotest.tools/gotestsum
     cd kritis


### PR DESCRIPTION
As a follow up to #600, this is preferred to avoid mess-ups to developer's local code.