### PR TITLE
Update policy template in signer test

### DIFF
--- a/integration/signer/policy_template.yaml
+++ b/integration/signer/policy_template.yaml
@@ -10,3 +10,4 @@ spec:
       - projects/goog-vulnz/notes/CVE-2020-10543
       - projects/goog-vulnz/notes/CVE-2020-10878
       - projects/goog-vulnz/notes/CVE-2020-14155
+      - projects/goog-vulnz/notes/CVE-2019-25013


### PR DESCRIPTION
This fixes the signer integration testing due to new vulnerability discovery. 

We'll probably need a more permanent solution for this.