### PR TITLE
Allow to use Docker images from Artifact Registry #613

### DIFF
--- a/pkg/kritis/metadata/containeranalysis/containeranalysis.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis.go
@@ -125,7 +125,7 @@ func (c Client) Attestations(containerImage string, aa *kritisv1beta1.Attestatio
 func (c Client) fetchVulnerabilityOccurrence(containerImage string, kind string) ([]*grafeas.Occurrence, error) {
 	// Make sure container image valid and is a GCR image
 	if !isValidImageOnGCP(containerImage) {
-		return nil, fmt.Errorf("%s is not a valid image hosted in GCR", containerImage)
+		return nil, fmt.Errorf("%s is not a valid image hosted in GCR or GAR", containerImage)
 	}
 
 	req := createListOccurrencesRequest(containerImage, kind)
@@ -257,7 +257,7 @@ func (c Client) CreateAttestationOccurrence(noteName string, containerImage stri
 // UploadAttestationOccurrence uploads an Attestation occurrence for a given note, image and project.
 func (c Client) UploadAttestationOccurrence(noteName string, containerImage string, att *attestlib.Attestation, proj string, sType metadata.SignatureType) (*grafeas.Occurrence, error) {
 	if !isValidImageOnGCP(containerImage) {
-		return nil, fmt.Errorf("%s is not a valid image hosted in GCR", containerImage)
+		return nil, fmt.Errorf("%s is not a valid image hosted in GCR or GAR", containerImage)
 	}
 
 	// Create occurrence from attestation

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis.go
@@ -124,7 +124,7 @@ func (c Client) Attestations(containerImage string, aa *kritisv1beta1.Attestatio
 
 func (c Client) fetchVulnerabilityOccurrence(containerImage string, kind string) ([]*grafeas.Occurrence, error) {
 	// Make sure container image valid and is a GCR image
-	if !isValidImageOnGCR(containerImage) {
+	if !isValidImageOnGCP(containerImage) {
 		return nil, fmt.Errorf("%s is not a valid image hosted in GCR", containerImage)
 	}
 
@@ -146,9 +146,9 @@ func (c Client) fetchVulnerabilityOccurrence(containerImage string, kind string)
 }
 
 func (c Client) fetchAttestationOccurrence(containerImage string, kind string, auth *kritisv1beta1.AttestationAuthority) ([]*grafeas.Occurrence, error) {
-	// Make sure container image valid and is a GCR image
-	if !isValidImageOnGCR(containerImage) {
-		return nil, fmt.Errorf("%s is not a valid image hosted in GCR", containerImage)
+	// Make sure container image valid and is a GCR or GAR image
+	if !isValidImageOnGCP(containerImage) {
+		return nil, fmt.Errorf("%s is not a valid image hosted in GCR or GAR", containerImage)
 	}
 
 	req := &grafeas.ListNoteOccurrencesRequest{
@@ -173,13 +173,13 @@ func (c Client) fetchAttestationOccurrence(containerImage string, kind string, a
 	return occs, nil
 }
 
-func isValidImageOnGCR(containerImage string) bool {
+func isValidImageOnGCP(containerImage string) bool {
 	ref, err := name.ParseReference(containerImage, name.WeakValidation)
 	if err != nil {
 		glog.Warning(err)
 		return false
 	}
-	return isRegistryGCR(ref.Context().RegistryStr())
+	return isRegistryGCR(ref.Context().RegistryStr()) || isRegistryGAR(ref.Context().RegistryStr())
 }
 
 func isRegistryGCR(r string) bool {
@@ -188,6 +188,20 @@ func isRegistryGCR(r string) bool {
 		return false
 	}
 	if registry[len(registry)-2] != "gcr" || registry[len(registry)-1] != "io" {
+		return false
+	}
+	return true
+}
+
+func isRegistryGAR(r string) bool {
+	registry := strings.Split(r, ".")
+	if len(registry) < 3 {
+		return false
+	}
+	if registry[len(registry)-2] != "pkg" || registry[len(registry)-1] != "dev" {
+		return false
+	}
+	if !strings.HasSuffix(registry[len(registry)-3], "-docker") {
 		return false
 	}
 	return true
@@ -242,7 +256,7 @@ func (c Client) CreateAttestationOccurrence(noteName string, containerImage stri
 
 // UploadAttestationOccurrence uploads an Attestation occurrence for a given note, image and project.
 func (c Client) UploadAttestationOccurrence(noteName string, containerImage string, att *attestlib.Attestation, proj string, sType metadata.SignatureType) (*grafeas.Occurrence, error) {
-	if !isValidImageOnGCR(containerImage) {
+	if !isValidImageOnGCP(containerImage) {
 		return nil, fmt.Errorf("%s is not a valid image hosted in GCR", containerImage)
 	}
 

--- a/pkg/kritis/metadata/containeranalysis/containeranalysis_test.go
+++ b/pkg/kritis/metadata/containeranalysis/containeranalysis_test.go
@@ -58,6 +58,46 @@ func Test_isRegistryGCR(t *testing.T) {
 	}
 }
 
+func Test_isRegistryGAR(t *testing.T) {
+	tests := []struct {
+		name     string
+		registry string
+		expected bool
+	}{
+		{
+			name:     "europe gar image",
+			registry: "europe-docker.pkg.dev",
+			expected: true,
+		},
+		{
+			name:     "us-central1 gar image",
+			registry: "us-central1-docker.pkg.dev",
+			expected: true,
+		},
+		{
+			name:     "invalid gar image",
+			registry: "pkg.dev",
+			expected: false,
+		},
+		{
+			name:     "non gar image",
+			registry: "index.docker.io",
+			expected: false,
+		},
+		{
+			name:     "invalid gar image",
+			registry: "europe-python.pkg.dev",
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := isRegistryGAR(test.registry)
+			testutil.DeepEqual(t, test.expected, actual)
+		})
+	}
+}
+
 func Test_getProjectFromContainerImage(t *testing.T) {
 	tests := []struct {
 		image   string


### PR DESCRIPTION
This Pull Request fixes the #613 issue by allowing to use docker image from [Google Artifact Registry](https://cloud.google.com/artifact-registry).

Given the naming of the actual validation function, I took the choice of creating a dedicated function to validate the syntax of Google Artifact Registries. (named GAR in my changes) 

I have choose to rename the isValidImageOnGCR to isValidImageOnGCP (Google Cloud Platform).

I'm not a specialist of Golang, so I'm open to any comment on my changes.

I am using this code on a forked Kritis image and it works like a charm.