### PR TITLE
Change maximum cve level to high in sample policies for test stability

### DIFF
--- a/integration/signer/policy_template.yaml
+++ b/integration/signer/policy_template.yaml
@@ -4,8 +4,8 @@ metadata:
   name: my-vsp
 spec:
   imageVulnerabilityRequirements:
-    maximumFixableSeverity: MEDIUM
-    maximumUnfixableSeverity: MEDIUM
+    maximumFixableSeverity: HIGH
+    maximumUnfixableSeverity: HIGH
     allowlistCVEs:
       - projects/goog-vulnz/notes/CVE-2021-20305
       - projects/goog-vulnz/notes/CVE-2020-10543

--- a/samples/policy-check/policy.yaml
+++ b/samples/policy-check/policy.yaml
@@ -4,8 +4,8 @@ metadata:
   name: my-vsp
 spec:
   imageVulnerabilityRequirements:
-    maximumFixableSeverity: MEDIUM
-    maximumUnfixableSeverity: MEDIUM
+    maximumFixableSeverity: HIGH
+    maximumUnfixableSeverity: HIGH
     allowlistCVEs:
     - projects/goog-vulnz/notes/CVE-2021-20305
     - projects/goog-vulnz/notes/CVE-2020-10543

--- a/samples/signer/policy.yaml
+++ b/samples/signer/policy.yaml
@@ -4,8 +4,8 @@ metadata:
   name: my-vsp
 spec:
   imageVulnerabilityRequirements:
-    maximumFixableSeverity: MEDIUM
-    maximumUnfixableSeverity: MEDIUM
+    maximumFixableSeverity: HIGH
+    maximumUnfixableSeverity: HIGH
     allowlistCVEs:
     - projects/goog-vulnz/notes/CVE-2021-20305
     - projects/goog-vulnz/notes/CVE-2020-10543


### PR DESCRIPTION
New discovered vulnz will break the "pass case" for our examples/integration tests. 
Change maximum CVE level to high in sample policies for better stability.